### PR TITLE
Add: Allow to set a timeout for rsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ New script for syncing the Greenbone Community Feed
   - [fail-fast](#fail-fast)
   - [no-wait](#no-wait)
   - [wait-interval](#wait-interval)
+  - [rsync-timeout](#rsync-timeout)
 - [Config](#config-1)
 - [Development](#development)
 - [Maintainer](#maintainer)
@@ -377,6 +378,16 @@ is only required for experts and testing purposes.
 | Environment Variable | `GREENBONE_FEED_SYNC_LOCK_WAIT_INTERVAL` |
 | Default Value | 5 |
 | Description | Time to wait in seconds after failed lock attempt before re-trying to lock the file. |
+
+### rsync-timeout
+
+| Name | Value |
+|------|-------|
+| CLI Argument | `--rsync-timeout` |
+| Config Variable  | rsync-timeout |
+| Environment Variable | `GREENBONE_FEED_SYNC_RSYNC_TIMEOUT` |
+| Default Value | |
+| Description | Maximum I/O timeout in seconds used for rsync. If no data is transferred for the specified time then rsync will exit. By default no timeout is set and the rsync default will be used. |
 
 ## Config
 

--- a/greenbone/feed/sync/parser.py
+++ b/greenbone/feed/sync/parser.py
@@ -193,6 +193,7 @@ _CONFIG = (
     ("private-directory", "GREENBONE_FEED_SYNC_PRIVATE_DIRECTORY", None, Path),
     ("verbose", "GREENBONE_FEED_SYNC_VERBOSE", None, int),
     ("fail-fast", "GREENBONE_FEED_SYNC_FAIL_FAST", False, bool),
+    ("rsync-timeout", "GREENBONE_FEED_SYNC_RSYNC_TIMEOUT", None, int),
 )
 
 
@@ -420,6 +421,14 @@ class CliParser:
             type=int,
             help="Time to wait in seconds after failed lock attempt before"
             "re-trying to lock the file. (Default: %(default)s seconds)",
+        )
+
+        parser.add_argument(
+            "--rsync-timeout",
+            type=int,
+            help="Maximum I/O timeout in seconds used for rsync. If no data is "
+            "transferred for the specified time then rsync will exit. By "
+            "default no timeout is set and the rsync default will be used.",
         )
 
         self.parser = parser

--- a/greenbone/feed/sync/rsync.py
+++ b/greenbone/feed/sync/rsync.py
@@ -40,6 +40,9 @@ async def exec_rsync(*args: Iterable[str]) -> None:
 
 DEFAULT_RSYNC_URL = "rsync://feed.community.greenbone.net/community"
 DEFAULT_RSYNC_COMPRESSION_LEVEL = 9
+DEFAULT_RSYNC_TIMEOUT = (
+    None  # in seconds. 0 means no timeout and None use rsync default
+)
 
 
 class Rsync:
@@ -52,11 +55,13 @@ class Rsync:
         *,
         verbose: bool = False,
         private_subdir: Optional[Path] = None,
-        compression_level: int = DEFAULT_RSYNC_COMPRESSION_LEVEL,
+        compression_level: Optional[int] = DEFAULT_RSYNC_COMPRESSION_LEVEL,
+        timeout: Optional[int] = DEFAULT_RSYNC_TIMEOUT,
     ) -> None:
         self.verbose = verbose
         self.private_subdir = private_subdir
         self.compression_level = compression_level
+        self.timeout = timeout
 
     async def sync(self, url: str, destination: Union[str, Path]) -> None:
         """
@@ -77,6 +82,14 @@ class Rsync:
             "--partial",
             "--progress",
         ]
+
+        rsync_timeout = (
+            [
+                f"--timeout={self.timeout}",
+            ]
+            if self.timeout is not None
+            else []
+        )
 
         rsync_compress = (
             [
@@ -107,6 +120,7 @@ class Rsync:
 
         args = (
             rsync_default_options
+            + rsync_timeout
             + rsync_verbose
             + rsync_compress
             + rsync_delete

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -105,7 +105,7 @@ class ConfigTestCase(unittest.TestCase):
     def test_defaults(self):
         values = Config.load()
 
-        self.assertEqual(len(values), 26)
+        self.assertEqual(len(values), 27)
         self.assertEqual(
             values["destination-prefix"], Path(DEFAULT_DESTINATION_PREFIX)
         )
@@ -188,6 +188,7 @@ class ConfigTestCase(unittest.TestCase):
         self.assertIsNone(values["private-directory"])
         self.assertIsNone(values["verbose"])
         self.assertFalse(values["fail-fast"])
+        self.assertIsNone(values["rsync-timeout"])
 
     def test_config_file(self):
         content = """[greenbone-feed-sync]
@@ -217,6 +218,7 @@ compression-level = 1
 private-directory = "keep-this"
 verbose = 5
 fail-fast = true
+rsync-timeout = 120
 """
         path_mock = MagicMock(spec=Path)
         path_mock.read_text.return_value = content
@@ -276,6 +278,7 @@ fail-fast = true
         self.assertEqual(values["private-directory"], Path("keep-this"))
         self.assertEqual(values["verbose"], 5)
         self.assertTrue(values["fail-fast"])
+        self.assertEqual(values["rsync-timeout"], 120)
 
     def test_destination_prefix(self):
         content = """[greenbone-feed-sync]
@@ -394,6 +397,7 @@ feed-url = "rsync://foo.bar"
             "GREENBONE_FEED_SYNC_PRIVATE_DIRECTORY": "keep-this",
             "GREENBONE_FEED_SYNC_VERBOSE": "5",
             "GREENBONE_FEED_SYNC_FAIL_FAST": "1",
+            "GREENBONE_FEED_SYNC_RSYNC_TIMEOUT": "120",
         },
     )
     def test_environment(self):
@@ -449,6 +453,7 @@ feed-url = "rsync://foo.bar"
         self.assertEqual(values["private-directory"], Path("keep-this"))
         self.assertEqual(values["verbose"], 5)
         self.assertTrue(values["fail-fast"])
+        self.assertEqual(values["rsync-timeout"], 120)
 
     @patch.dict(
         "os.environ",
@@ -479,6 +484,7 @@ feed-url = "rsync://foo.bar"
             "GREENBONE_FEED_SYNC_PRIVATE_DIRECTORY": "keep-this",
             "GREENBONE_FEED_SYNC_VERBOSE": "5",
             "GREENBONE_FEED_SYNC_FAIL_FAST": "1",
+            "GREENBONE_FEED_SYNC_RSYNC_TIMEOUT": "120",
         },
     )
     def test_environment_overrides_config_file(self):
@@ -509,6 +515,7 @@ compression-level = 7
 private-directory = "private"
 verbose = 99
 fail-fast = false
+rsync-timeout = 360
 """
         path_mock = MagicMock(spec=Path)
         path_mock.read_text.return_value = content
@@ -565,6 +572,7 @@ fail-fast = false
         self.assertEqual(values["private-directory"], Path("keep-this"))
         self.assertEqual(values["verbose"], 5)
         self.assertTrue(values["fail-fast"])
+        self.assertEqual(values["rsync-timeout"], 120)
 
     def test_invalid_toml(self):
         content = "This is not TOML"
@@ -694,6 +702,7 @@ class CliParserTestCase(unittest.TestCase):
         self.assertIsNone(args.private_directory)
         self.assertIsNone(args.verbose)
         self.assertFalse(args.fail_fast)
+        self.assertIsNone(args.rsync_timeout)
 
     def test_help(self):
         parser = CliParser()
@@ -913,6 +922,11 @@ class CliParserTestCase(unittest.TestCase):
         parser = CliParser()
         args = parser.parse_arguments(["--wait-interval", "100"])
         self.assertEqual(args.wait_interval, 100)
+
+    def test_rsync_timeout(self):
+        parser = CliParser()
+        args = parser.parse_arguments(["--rsync-timeout", "120"])
+        self.assertEqual(args.rsync_timeout, 120)
 
     def test_other(self):
         parser = CliParser()

--- a/tests/test_rsync.py
+++ b/tests/test_rsync.py
@@ -162,3 +162,27 @@ class ExecRsyncTestCase(unittest.IsolatedAsyncioTestCase):
         exec_mock.assert_awaited_once_with(
             "rsync", "foo", "bar", stderr=asyncio.subprocess.PIPE
         )
+
+    @patch("greenbone.feed.sync.rsync.exec_rsync", autospec=True)
+    async def test_rsync_with_timeout(self, exec_mock: AsyncMock):
+        rsync = Rsync(timeout=120)
+        await rsync.sync("rsync://foo.bar/baz", "/tmp/baz")
+
+        exec_mock.assert_awaited_once_with(
+            "--links",
+            "--times",
+            "--omit-dir-times",
+            "--recursive",
+            "--partial",
+            "--progress",
+            "--timeout=120",
+            "-q",
+            "--compress-level=9",
+            "--delete",
+            "--perms",
+            "--chmod=Fugo+r,Fug+w,Dugo-s,Dugo+rx,Dug+w",
+            "--copy-unsafe-links",
+            "--hard-links",
+            "rsync://foo.bar/baz",
+            "/tmp/baz",
+        )


### PR DESCRIPTION
## What

Allow to set a timeout for rsync

## Why

Add a new rsync-timeout setting to allow to change the rsync timeout behavior. By default rsync should wait forever which is the same as using 0 as timeout value.