### PR TITLE
Change: Ensure the lock file is read and writable by the users group

### DIFF
--- a/greenbone/feed/sync/helper.py
+++ b/greenbone/feed/sync/helper.py
@@ -84,6 +84,7 @@ async def flock_wait(
                     console.print(f"Acquired lock on {path.absolute()}")
 
                 has_lock = True
+                path.chmod(mode=0o660)
             except OSError as e:
                 if e.errno in (errno.EAGAIN, errno.EACCES):
                     if wait_interval is None:


### PR DESCRIPTION
## What

Ensure the lock file is read and writable by the users group

## Why

When creating a lock file for a feed ensure that the group can read and write the lock file. This change ensure that the same permissions are applied as with gvmd, ospd-openvas and the old sync scripts.

