### PR TITLE
Add: When running as root switch to different user and group

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ New script for syncing the Greenbone Community Feed
   - [no-wait](#no-wait)
   - [wait-interval](#wait-interval)
   - [rsync-timeout](#rsync-timeout)
+  - [group](#group)
+  - [user](#user)
 - [Config](#config-1)
 - [Development](#development)
 - [Maintainer](#maintainer)
@@ -388,6 +390,26 @@ is only required for experts and testing purposes.
 | Environment Variable | `GREENBONE_FEED_SYNC_RSYNC_TIMEOUT` |
 | Default Value | |
 | Description | Maximum I/O timeout in seconds used for rsync. If no data is transferred for the specified time then rsync will exit. By default no timeout is set and the rsync default will be used. |
+
+### group
+
+| Name | Value |
+|------|-------|
+| CLI Argument | `--group` |
+| Config Variable  | group |
+| Environment Variable | `GREENBONE_FEED_SYNC_GROUP` |
+| Default Value | gvm |
+| Description | If the greenbone-feed-sync script is run as root, the effective group is changed to this group name or ID. |
+
+### user
+
+| Name | Value |
+|------|-------|
+| CLI Argument | `--user` |
+| Config Variable  | user |
+| Environment Variable | `GREENBONE_FEED_SYNC_USER` |
+| Default Value | gvm |
+| Description | If the greenbone-feed-sync script is run as root, the effective user is changed to this user name or ID. |
 
 ## Config
 

--- a/greenbone/feed/sync/helper.py
+++ b/greenbone/feed/sync/helper.py
@@ -19,6 +19,7 @@ import asyncio
 import errno
 import fcntl
 import os
+import shutil
 from contextlib import asynccontextmanager
 from pathlib import Path
 from types import TracebackType
@@ -138,3 +139,22 @@ class Spinner:
         exc_tb: Optional[TracebackType],
     ) -> None:
         self._live.stop()
+
+
+def change_user_and_group(
+    user: Union[str, int], group: Union[str, int]
+) -> None:
+    """
+    Change effective user or group of the current running process
+
+    Args:
+        user: User name or ID
+        group: Group name or ID
+    """
+    if isinstance(user, str):
+        user = shutil._get_uid(user)  # pylint: disable=protected-access
+    if isinstance(group, str):
+        group = shutil._get_gid(group)  # pylint: disable=protected-access
+
+    os.seteuid(user)
+    os.setegid(group)

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -24,7 +24,12 @@ from pontos.testing import temp_directory
 from rich.console import Console
 
 from greenbone.feed.sync.errors import FileLockingError
-from greenbone.feed.sync.helper import Spinner, flock_wait, is_root
+from greenbone.feed.sync.helper import (
+    Spinner,
+    change_user_and_group,
+    flock_wait,
+    is_root,
+)
 
 
 class FlockTestCase(unittest.IsolatedAsyncioTestCase):
@@ -176,3 +181,13 @@ class IsRootTestCase(unittest.TestCase):
         geteuid_mock.return_value = 0
 
         self.assertTrue(is_root())
+
+
+class ChangeUserAndGroupTestCase(unittest.TestCase):
+    @patch("greenbone.feed.sync.helper.os", autospec=True)
+    def test_change(self, os_mock: MagicMock):
+        # root user should exist on all systems
+        change_user_and_group("root", "root")
+
+        os_mock.seteuid.assert_called_once_with(0)
+        os_mock.setegid.assert_called_once_with(0)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -30,6 +30,7 @@ from greenbone.feed.sync.parser import (
     DEFAULT_CERT_DATA_URL_PATH,
     DEFAULT_CONFIG_FILE,
     DEFAULT_DESTINATION_PREFIX,
+    DEFAULT_GROUP,
     DEFAULT_GVMD_DATA_PATH,
     DEFAULT_GVMD_DATA_URL_PATH,
     DEFAULT_GVMD_LOCK_FILE_PATH,
@@ -46,6 +47,7 @@ from greenbone.feed.sync.parser import (
     DEFAULT_SCAN_CONFIGS_URL_PATH,
     DEFAULT_SCAP_DATA_PATH,
     DEFAULT_SCAP_DATA_URL_PATH,
+    DEFAULT_USER,
     DEFAULT_USER_CONFIG_FILE,
     CliParser,
     Config,
@@ -105,7 +107,7 @@ class ConfigTestCase(unittest.TestCase):
     def test_defaults(self):
         values = Config.load()
 
-        self.assertEqual(len(values), 27)
+        self.assertEqual(len(values), 29)
         self.assertEqual(
             values["destination-prefix"], Path(DEFAULT_DESTINATION_PREFIX)
         )
@@ -189,6 +191,8 @@ class ConfigTestCase(unittest.TestCase):
         self.assertIsNone(values["verbose"])
         self.assertFalse(values["fail-fast"])
         self.assertIsNone(values["rsync-timeout"])
+        self.assertEqual(values["group"], DEFAULT_GROUP)
+        self.assertEqual(values["user"], DEFAULT_USER)
 
     def test_config_file(self):
         content = """[greenbone-feed-sync]
@@ -219,6 +223,8 @@ private-directory = "keep-this"
 verbose = 5
 fail-fast = true
 rsync-timeout = 120
+group = "foo"
+user = "bar"
 """
         path_mock = MagicMock(spec=Path)
         path_mock.read_text.return_value = content
@@ -279,6 +285,8 @@ rsync-timeout = 120
         self.assertEqual(values["verbose"], 5)
         self.assertTrue(values["fail-fast"])
         self.assertEqual(values["rsync-timeout"], 120)
+        self.assertEqual(values["group"], "foo")
+        self.assertEqual(values["user"], "bar")
 
     def test_destination_prefix(self):
         content = """[greenbone-feed-sync]
@@ -398,6 +406,8 @@ feed-url = "rsync://foo.bar"
             "GREENBONE_FEED_SYNC_VERBOSE": "5",
             "GREENBONE_FEED_SYNC_FAIL_FAST": "1",
             "GREENBONE_FEED_SYNC_RSYNC_TIMEOUT": "120",
+            "GREENBONE_FEED_SYNC_GROUP": "123",
+            "GREENBONE_FEED_SYNC_USER": "321",
         },
     )
     def test_environment(self):
@@ -454,6 +464,8 @@ feed-url = "rsync://foo.bar"
         self.assertEqual(values["verbose"], 5)
         self.assertTrue(values["fail-fast"])
         self.assertEqual(values["rsync-timeout"], 120)
+        self.assertEqual(values["group"], 123)
+        self.assertEqual(values["user"], 321)
 
     @patch.dict(
         "os.environ",
@@ -1179,3 +1191,19 @@ wait-interval = 100
         self.assertEqual(args.type, "gvmd-data")
         args = parser.parse_arguments(["--type", "gvmd-data"])
         self.assertEqual(args.type, "gvmd-data")
+
+    def test_group(self):
+        parser = CliParser()
+        args = parser.parse_arguments(["--group", "some_group"])
+        self.assertEqual(args.group, "some_group")
+
+        args = parser.parse_arguments(["--group", "123"])
+        self.assertEqual(args.group, 123)
+
+    def test_user(self):
+        parser = CliParser()
+        args = parser.parse_arguments(["--user", "some_user"])
+        self.assertEqual(args.user, "some_user")
+
+        args = parser.parse_arguments(["--user", "123"])
+        self.assertEqual(args.user, 123)


### PR DESCRIPTION
## What

When running as root switch to different user and group

## Why

Instead of forbid running as root, switch to a different effective user and group that both can be configured. By default user and group name are `gvm`. This allows running `greenbone-feed-sync` via a superuser tool like `sudo` or `gosu` without having to remember the special user it needs to run with.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


