### PR TITLE
Change: Use standard release action

### DIFF
--- a/.github/workflows/release-pontos.yml
+++ b/.github/workflows/release-pontos.yml
@@ -25,7 +25,7 @@ jobs:
             echo "RELEASE_REF=${{ github.base_ref }}" >> $GITHUB_ENV
           fi
       - name: Release with release action
-        uses: greenbone/actions/release-python@v2
+        uses: greenbone/actions/release@v2
         with:
           version: "3.10"
           conventional-commits: true


### PR DESCRIPTION
## What

Use standard release action

## Why

Use our standard release action as the Python one is deprecated.

## References

DEVOPS-539

