### PR TITLE
Fix: Fix changing the group when running as root

### DIFF
--- a/greenbone/feed/sync/helper.py
+++ b/greenbone/feed/sync/helper.py
@@ -156,5 +156,5 @@ def change_user_and_group(
     if isinstance(group, str):
         group = shutil._get_gid(group)  # pylint: disable=protected-access
 
-    os.seteuid(user)
     os.setegid(group)
+    os.seteuid(user)


### PR DESCRIPTION
## What

Fix changing the group when running as root

## Why

When changing the effective group and user of the current process the group id must be changed before the user id because otherwise it wont be possible to change the group anymore.


