### PR TITLE
Add: selftest command line option.

### DIFF
--- a/greenbone/feed/sync/main.py
+++ b/greenbone/feed/sync/main.py
@@ -81,7 +81,7 @@ def do_selftest(error_console: Console) -> int:
             stderr=subprocess.DEVNULL,
             check=True,
         )
-    except PermissionError:
+    except (PermissionError, FileNotFoundError, subprocess.CalledProcessError):
         error_console.print("The sha256sum binary could not be found.")
         return 1
 
@@ -92,7 +92,7 @@ def do_selftest(error_console: Console) -> int:
             stderr=subprocess.DEVNULL,
             check=True,
         )
-    except PermissionError:
+    except (PermissionError, FileNotFoundError, subprocess.CalledProcessError):
         error_console.print("The rsync binary could not be found.")
         return 1
 

--- a/greenbone/feed/sync/main.py
+++ b/greenbone/feed/sync/main.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
+import subprocess
 import sys
 from dataclasses import dataclass
 from typing import Iterable, NoReturn
@@ -69,12 +70,44 @@ def filter_syncs(
     )
 
 
+def do_selftest(error_console: Console) -> int:
+    """
+    Check for sha256sum and rsync commands.
+    """
+    try:
+        subprocess.run(
+            ["sha256sum", "--help"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+    except PermissionError:
+        error_console.print("The sha256sum binary could not be found.")
+        return 1
+
+    try:
+        subprocess.run(
+            ["rsync", "--help"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+    except PermissionError:
+        error_console.print("The rsync binary could not be found.")
+        return 1
+
+    return 0
+
+
 async def feed_sync(console: Console, error_console: Console) -> int:
     """
     Sync the feeds
     """
     parser = CliParser()
     args = parser.parse_arguments()
+
+    if args.selftest:
+        return do_selftest(error_console)
 
     if args.quiet:
         verbose = 0

--- a/greenbone/feed/sync/parser.py
+++ b/greenbone/feed/sync/parser.py
@@ -256,7 +256,11 @@ class CliParser:
             help="Show this help message and exit.",
             action="store_true",
         )
-
+        parser.add_argument(
+            "--selftest",
+            help="Perform self-test and set exit code",
+            action="store_true",
+        )
         output_group = parser.add_mutually_exclusive_group()
         output_group.add_argument(
             "--verbose",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -750,6 +750,11 @@ class CliParserTestCase(unittest.TestCase):
         args = parser.parse_arguments(["--quiet"])
         self.assertTrue(args.quiet)
 
+    def test_selftest(self):
+        parser = CliParser()
+        args = parser.parse_arguments(["--selftest"])
+        self.assertTrue(args.selftest)
+
     @patch("greenbone.feed.sync.parser.Path")
     def test_use_default_config_files(self, path_mock: Path):
         path_mock_instance = path_mock.return_value


### PR DESCRIPTION
## What
Add: selftest command line option.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
Since this script replace the `greenbone-nvt-sync`, it must provide at least the option which are still required by other modules Ospd-openvas calls it with `--selftest` and sent this information to gvmd. The GMP related command is `<get_feeds/>`

<!-- Describe why are these changes necessary? -->

## References

<!-- Add links to issue tickets, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


