### PR TITLE
Support old script names

### DIFF
--- a/greenbone/feed/sync/parser.py
+++ b/greenbone/feed/sync/parser.py
@@ -350,6 +350,13 @@ class CliParser:
                 "greenbone-enterprise-feed-key"
             ] = known_args.greenbone_enterprise_feed_key
 
+        if self.parser.prog == "greenbone-nvt-sync":
+            config["type"] = "nvt"
+        elif self.parser.prog == "greenbone-scapdata-sync":
+            config["type"] = "scap"
+        elif self.parser.prog == "greenbone-certdata-sync":
+            config["type"] = "cert"
+
         # apply defaults in config
         config.apply_settings()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ coverage = {extras = ["toml"], version = "^7.1.0"}
 
 [tool.poetry.scripts]
 greenbone-feed-sync = 'greenbone.feed.sync.main:main'
+greenbone-nvt-sync = 'greenbone.feed.sync.main:main'
+greenbone-scapdata-sync = 'greenbone.feed.sync.main:main'
+greenbone-certdata-sync = 'greenbone.feed.sync.main:main'
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -18,6 +18,7 @@
 # pylint: disable=line-too-long, too-many-lines
 
 import io
+import sys
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
@@ -128,6 +129,8 @@ class CliParserTestCase(unittest.TestCase):
     def test_defaults(self):
         parser = CliParser()
         args = parser.parse_arguments([])
+
+        self.assertEqual(args.type, "all")
         self.assertEqual(
             args.destination_prefix, Path(DEFAULT_DESTINATION_PREFIX)
         )
@@ -811,3 +814,24 @@ sed diam nonumy eirmod tempor
             args.cert_data_url,
             "rsync://feed.community.greenbone.net/community/vulnerability-feed/22.04/cert-data/",
         )
+
+    @patch.object(sys, "argv", ["greenbone-nvt-sync"])
+    def test_greenbone_nvt_sync(self):
+        parser = CliParser()
+        args = parser.parse_arguments([])
+
+        self.assertEqual(args.type, "nvt")
+
+    @patch.object(sys, "argv", ["greenbone-scapdata-sync"])
+    def test_greenbone_scap_data_sync(self):
+        parser = CliParser()
+        args = parser.parse_arguments([])
+
+        self.assertEqual(args.type, "scap")
+
+    @patch.object(sys, "argv", ["greenbone-certdata-sync"])
+    def test_greenbone_cert_data_sync(self):
+        parser = CliParser()
+        args = parser.parse_arguments([])
+
+        self.assertEqual(args.type, "cert")


### PR DESCRIPTION
## What

Support old script names like greenbone-nvt-sync

Requires #51

## Why

Because there are a lot of documents in the internet mentioning the old script names like greenbone-nvt-sync we still should support them. This changes installs python scripts with the old script names and set the type argument default accordingly to the called script. For example if the script greenbone-nvt-sync is called the type argument default will be nvt.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


