### PR TITLE
Change: Always run selftest

### DIFF
--- a/greenbone/feed/sync/main.py
+++ b/greenbone/feed/sync/main.py
@@ -71,7 +71,7 @@ def filter_syncs(
     )
 
 
-def do_selftest(error_console: Console) -> int:
+def do_selftest() -> None:
     """
     Check for sha256sum and rsync commands.
     """
@@ -83,8 +83,9 @@ def do_selftest(error_console: Console) -> int:
             check=True,
         )
     except (PermissionError, FileNotFoundError, subprocess.CalledProcessError):
-        error_console.print("The sha256sum binary could not be found.")
-        return 1
+        raise GreenboneFeedSyncError(
+            "The sha256sum binary could not be found."
+        ) from None
 
     try:
         subprocess.run(
@@ -94,10 +95,9 @@ def do_selftest(error_console: Console) -> int:
             check=True,
         )
     except (PermissionError, FileNotFoundError, subprocess.CalledProcessError):
-        error_console.print("The rsync binary could not be found.")
-        return 1
-
-    return 0
+        raise GreenboneFeedSyncError(
+            "The rsync binary could not be found."
+        ) from None
 
 
 async def feed_sync(console: Console, error_console: Console) -> int:
@@ -107,8 +107,10 @@ async def feed_sync(console: Console, error_console: Console) -> int:
     parser = CliParser()
     args = parser.parse_arguments()
 
+    do_selftest()
+
     if args.selftest:
-        return do_selftest(error_console)
+        return 0
 
     if args.quiet:
         verbose = 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -55,25 +55,25 @@ class FilterSyncsTestCase(unittest.TestCase):
 
 class DoSelftestTestCase(unittest.TestCase):
     @patch("greenbone.feed.sync.main.subprocess.run")
-    def test_do_selftest(self, mock_subproc_run: MagicMock):
-        mock_subproc_run.side_effect = [b"foo", b"bar"]
-        console = MagicMock()
-
-        self.assertEqual(do_selftest(console), 0)
+    def test_do_selftest_success(self, mock_subprocess_run: MagicMock):
+        mock_subprocess_run.side_effect = ["", ""]
+        do_selftest()
 
     @patch("greenbone.feed.sync.main.subprocess.run")
-    def test_do_selftest_sha_fail(self, mock_subproc_run: MagicMock):
-        mock_subproc_run.side_effect = [b"foo", PermissionError]
-        console = MagicMock()
-
-        self.assertEqual(do_selftest(console), 1)
+    def test_do_selftest_sha356sum_fail(self, mock_subprocess_run: MagicMock):
+        mock_subprocess_run.side_effect = [PermissionError, ""]
+        with self.assertRaisesRegex(
+            GreenboneFeedSyncError, "The sha256sum binary could not be found."
+        ):
+            do_selftest()
 
     @patch("greenbone.feed.sync.main.subprocess.run")
-    def test_do_selftest_rsync_fail(self, mock_subproc_run: MagicMock):
-        mock_subproc_run.side_effect = [PermissionError, b"bar"]
-        console = MagicMock()
-
-        self.assertEqual(do_selftest(console), 1)
+    def test_do_selftest_rsync_fail(self, mock_subprocess_run: MagicMock):
+        mock_subprocess_run.side_effect = ["", PermissionError]
+        with self.assertRaisesRegex(
+            GreenboneFeedSyncError, "The rsync binary could not be found."
+        ):
+            do_selftest()
 
 
 class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## What

Always run selftest

## Why

Refactor selftest to raise exception instead of using C-style return values. Using exceptions allows for CLI output in the caller and makes the function independent of a user interface.

Also do the selftest on every run to give the user feedback about missing but required applications.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


