### PR TITLE
Remove: Drop check for sha256sum in selftest

### DIFF
--- a/greenbone/feed/sync/main.py
+++ b/greenbone/feed/sync/main.py
@@ -73,20 +73,8 @@ def filter_syncs(
 
 def do_selftest() -> None:
     """
-    Check for sha256sum and rsync commands.
+    Check for rsync command.
     """
-    try:
-        subprocess.run(
-            ["sha256sum", "--help"],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            check=True,
-        )
-    except (PermissionError, FileNotFoundError, subprocess.CalledProcessError):
-        raise GreenboneFeedSyncError(
-            "The sha256sum binary could not be found."
-        ) from None
-
     try:
         subprocess.run(
             ["rsync", "--help"],

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -56,20 +56,12 @@ class FilterSyncsTestCase(unittest.TestCase):
 class DoSelftestTestCase(unittest.TestCase):
     @patch("greenbone.feed.sync.main.subprocess.run")
     def test_do_selftest_success(self, mock_subprocess_run: MagicMock):
-        mock_subprocess_run.side_effect = ["", ""]
+        mock_subprocess_run.side_effect = [""]
         do_selftest()
 
     @patch("greenbone.feed.sync.main.subprocess.run")
-    def test_do_selftest_sha356sum_fail(self, mock_subprocess_run: MagicMock):
-        mock_subprocess_run.side_effect = [PermissionError, ""]
-        with self.assertRaisesRegex(
-            GreenboneFeedSyncError, "The sha256sum binary could not be found."
-        ):
-            do_selftest()
-
-    @patch("greenbone.feed.sync.main.subprocess.run")
     def test_do_selftest_rsync_fail(self, mock_subprocess_run: MagicMock):
-        mock_subprocess_run.side_effect = ["", PermissionError]
+        mock_subprocess_run.side_effect = [PermissionError]
         with self.assertRaisesRegex(
             GreenboneFeedSyncError, "The rsync binary could not be found."
         ):


### PR DESCRIPTION
## What

Drop check for sha256sum in selftest

## Why

The application sha256sum is not used in the greenbone-feed-sync script. The script should only check for things it actually uses.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


