### PR TITLE
Fix: Set permission on conventional commits workflow

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -3,6 +3,9 @@ name: Conventional Commits
 on:
   pull_request:
 
+permissions:
+  pull-requests: write
+
 jobs:
   conventional-commits:
     name: Conventional Commits


### PR DESCRIPTION


## What

Set permission on conventional commits workflow

## Why

Without setting pull-request write permissions the workflow is failing at the moment.