### PR TITLE
Change: Resolve deprecation warnings in GitHub workflows

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -13,15 +13,16 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.9
+          - "3.9"
           - "3.10"
+          - "3.11"
     steps:
       - uses: actions/checkout@v3
       - name: Install and check with black, pylint and pontos.version
         uses: greenbone/actions/lint-python@v2
         with:
           packages: greenbone tests
-          version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
 
   test:
     name: Run all tests
@@ -29,7 +30,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.9
+          - "3.9"
           - "3.10"
           - "3.11"
     steps:
@@ -37,7 +38,7 @@ jobs:
       - name: Install python, poetry and dependencies
         uses: greenbone/actions/poetry@v2
         with:
-          version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
       - name: Run unit tests
         run: poetry run python -m unittest
 
@@ -50,5 +51,5 @@ jobs:
       - name: Install and calculate and upload coverage to codecov.io
         uses: greenbone/actions/coverage-python@v2
         with:
-          version: "3.10"
+          python-version: "3.10"
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION


## What

Use python-version input instead of version

## Why

Resolve deprecation warnings in GitHub workflows

