### PR TITLE
Fix README for installation with pipx

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,23 +60,28 @@ within the `PATH`.
 
 On Debian based Distributions like Ubuntu and Kali `rsync` can be installed via
 
-    apt install rsync
+    sudo apt install rsync
 
 ### Install using pipx
 
-You can install the latest stable release of **pontos** from the Python
+You can install the latest release of **greenbone-feed-sync** from the Python
 Package Index (pypi) using [pipx]
 
-    python3 -m pipx install pontos
+    python3 -m pipx install greenbone-feed-sync
+
+On Debian based Distributions like Ubuntu and Kali `pipx` itself can be
+installed via
+
+    sudo apt install pipx
 
 ### Install using pip
 
 **NOTE:** The `pip install` command does no longer work out-of-the-box in newer
-distributions like Ubuntu 23.04 because of [PEP 668](https://peps.python.org/pep-0668).
+distributions like Ubuntu 23.04 or Debian 12 because of [PEP 668](https://peps.python.org/pep-0668).
 Please use the [installation via pipx](#install-using-pipx) instead.
 
-You can install the latest stable release of **greenbone-feed-sync** from the
-Python Package Index (pypi) using [pip]
+You can install the latest release of **greenbone-feed-sync** from the
+Python Package Index ([pypi]) using [pip]
 
     python3 -m pip install greenbone-feed-sync
 
@@ -506,3 +511,4 @@ Licensed under the [GNU General Public License v3.0 or later](LICENSE).
 [pipx]: https://pypa.github.io/pipx/
 [autohooks]: https://github.com/greenbone/autohooks
 [TOML]: https://toml.io/
+[pypi]: https://pypi.org


### PR DESCRIPTION


## What

Fix README for installation with pipx

## Why
Fix copy and paste mistake for chapter about using pipx for installing greenbon-feed-sync. Also add some more improvements like using sudo for apt install.
