### PR TITLE
Make errors more visible in the terminal

### DIFF
--- a/greenbone/feed/sync/main.py
+++ b/greenbone/feed/sync/main.py
@@ -234,7 +234,7 @@ def main() -> NoReturn:
     try:
         sys.exit(asyncio.run(feed_sync(console, error_console)))
     except GreenboneFeedSyncError as e:
-        error_console.print(str(e))
+        error_console.print(f"[red]❌[/red]Error: {e}")
         sys.exit(1)
     except KeyboardInterrupt:
         sys.exit(1)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -449,7 +449,7 @@ class MainFunctionTestCase(unittest.TestCase):
                     call(
                         f"Releasing lock on {temp_dir}/openvas/feed-update.lock"
                     ),
-                    call("An error"),
+                    call("[red]❌[/red]Error: An error"),
                 ]
             )
 


### PR DESCRIPTION

## What

Make errors more visible in the terminal
## Why
Don't let errors look like normal terminal output. Instead highlight the error.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


