### PR TITLE
Check if user and group exists when running as sudo

### DIFF
--- a/greenbone/feed/sync/helper.py
+++ b/greenbone/feed/sync/helper.py
@@ -29,7 +29,7 @@ from rich.console import Console
 from rich.live import Live
 from rich.spinner import Spinner as RichSpinner
 
-from greenbone.feed.sync.errors import FileLockingError
+from greenbone.feed.sync.errors import FileLockingError, GreenboneFeedSyncError
 
 DEFAULT_FLOCK_WAIT_INTERVAL = 5  # in seconds
 
@@ -152,9 +152,19 @@ def change_user_and_group(
         group: Group name or ID
     """
     if isinstance(user, str):
-        user = shutil._get_uid(user)  # pylint: disable=protected-access
+        user_id = shutil._get_uid(user)  # pylint: disable=protected-access
+        if user_id is None:
+            raise GreenboneFeedSyncError(
+                f"Can't run as user '{user}'. User '{user}' is unknown."
+            )
+        user = user_id
     if isinstance(group, str):
-        group = shutil._get_gid(group)  # pylint: disable=protected-access
+        group_id = shutil._get_gid(group)  # pylint: disable=protected-access
+        if group_id is None:
+            raise GreenboneFeedSyncError(
+                f"Can't run as group '{group}'. Group '{group}' is unknown."
+            )
+        group = group_id
 
     os.setegid(group)
     os.seteuid(user)


### PR DESCRIPTION


## What

Check if user and group exists when running as sudo

## Why

Create helpful error message when running as root and trying to switch to an non existing user or group.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


