### PR TITLE
refactor: Replace hardcoded version number with a constant

### DIFF
--- a/greenbone/feed/sync/config.py
+++ b/greenbone/feed/sync/config.py
@@ -46,14 +46,18 @@ def maybe_int(value: Optional[str]) -> Union[int, str, None]:
     return value
 
 
-DEFAULT_NOTUS_URL_PATH = "/vulnerability-feed/22.04/vt-data/notus/"
-DEFAULT_NASL_URL_PATH = "/vulnerability-feed/22.04/vt-data/nasl/"
-DEFAULT_SCAP_DATA_URL_PATH = "/vulnerability-feed/22.04/scap-data/"
-DEFAULT_CERT_DATA_URL_PATH = "/vulnerability-feed/22.04/cert-data/"
-DEFAULT_GVMD_DATA_URL_PATH = "/data-feed/22.04/"
-DEFAULT_REPORT_FORMATS_URL_PATH = "/data-feed/22.04/report-formats/"
-DEFAULT_SCAN_CONFIGS_URL_PATH = "/data-feed/22.04/scan-configs/"
-DEFAULT_PORT_LISTS_URL_PATH = "/data-feed/22.04/port-lists/"
+DEFAULT_VERSION = "22.04"
+
+DEFAULT_NOTUS_URL_PATH = f"/vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/"
+DEFAULT_NASL_URL_PATH = f"/vulnerability-feed/{DEFAULT_VERSION}/vt-data/nasl/"
+DEFAULT_SCAP_DATA_URL_PATH = f"/vulnerability-feed/{DEFAULT_VERSION}/scap-data/"
+DEFAULT_CERT_DATA_URL_PATH = f"/vulnerability-feed/{DEFAULT_VERSION}/cert-data/"
+DEFAULT_GVMD_DATA_URL_PATH = f"/data-feed/{DEFAULT_VERSION}/"
+DEFAULT_REPORT_FORMATS_URL_PATH = (
+    f"/data-feed/{DEFAULT_VERSION}/report-formats/"
+)
+DEFAULT_SCAN_CONFIGS_URL_PATH = f"/data-feed/{DEFAULT_VERSION}/scan-configs/"
+DEFAULT_PORT_LISTS_URL_PATH = f"/data-feed/{DEFAULT_VERSION}/port-lists/"
 
 DEFAULT_DESTINATION_PREFIX = "/var/lib/"
 
@@ -61,10 +65,14 @@ DEFAULT_NASL_PATH = "openvas/plugins"
 DEFAULT_NOTUS_PATH = "notus"
 DEFAULT_SCAP_DATA_PATH = "gvm/scap-data"
 DEFAULT_CERT_DATA_PATH = "gvm/cert-data"
-DEFAULT_GVMD_DATA_PATH = "gvm/data-objects/gvmd/22.04/"
-DEFAULT_REPORT_FORMATS_PATH = "gvm/data-objects/gvmd/22.04/report-formats"
-DEFAULT_SCAN_CONFIGS_PATH = "gvm/data-objects/gvmd/22.04/scan-configs"
-DEFAULT_PORT_LISTS_PATH = "gvm/data-objects/gvmd/22.04/port-lists"
+DEFAULT_GVMD_DATA_PATH = f"gvm/data-objects/gvmd/{DEFAULT_VERSION}/"
+DEFAULT_REPORT_FORMATS_PATH = (
+    f"gvm/data-objects/gvmd/{DEFAULT_VERSION}/report-formats"
+)
+DEFAULT_SCAN_CONFIGS_PATH = (
+    f"gvm/data-objects/gvmd/{DEFAULT_VERSION}/scan-configs"
+)
+DEFAULT_PORT_LISTS_PATH = f"gvm/data-objects/gvmd/{DEFAULT_VERSION}/port-lists"
 
 DEFAULT_GVMD_LOCK_FILE_PATH = "gvm/feed-update.lock"
 DEFAULT_OPENVAS_LOCK_FILE_PATH = "openvas/feed-update.lock"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,6 +47,7 @@ from greenbone.feed.sync.config import (
     DEFAULT_SCAP_DATA_PATH,
     DEFAULT_SCAP_DATA_URL_PATH,
     DEFAULT_USER,
+    DEFAULT_VERSION,
     Config,
     EnterpriseSettings,
 )
@@ -264,7 +265,7 @@ destination-prefix = "/opt/lib/"
         self.assertEqual(values["destination-prefix"], Path("/opt/lib"))
         self.assertEqual(
             values["gvmd-data-destination"],
-            Path("/opt/lib/gvm/data-objects/gvmd/22.04"),
+            Path(f"/opt/lib/gvm/data-objects/gvmd/{DEFAULT_VERSION}"),
         )
         self.assertEqual(values["notus-destination"], Path("/opt/lib/notus"))
         self.assertEqual(
@@ -278,15 +279,21 @@ destination-prefix = "/opt/lib/"
         )
         self.assertEqual(
             values["report-formats-destination"],
-            Path("/opt/lib/gvm/data-objects/gvmd/22.04/report-formats"),
+            Path(
+                f"/opt/lib/gvm/data-objects/gvmd/{DEFAULT_VERSION}/report-formats"
+            ),
         )
         self.assertEqual(
             values["scan-configs-destination"],
-            Path("/opt/lib/gvm/data-objects/gvmd/22.04/scan-configs"),
+            Path(
+                f"/opt/lib/gvm/data-objects/gvmd/{DEFAULT_VERSION}/scan-configs"
+            ),
         )
         self.assertEqual(
             values["port-lists-destination"],
-            Path("/opt/lib/gvm/data-objects/gvmd/22.04/port-lists"),
+            Path(
+                f"/opt/lib/gvm/data-objects/gvmd/{DEFAULT_VERSION}/port-lists"
+            ),
         )
         self.assertEqual(
             values["openvas-lock-file"],
@@ -308,35 +315,35 @@ feed-url = "rsync://foo.bar"
         self.assertEqual(values["feed-url"], "rsync://foo.bar")
         self.assertEqual(
             values["gvmd-data-url"],
-            "rsync://foo.bar/data-feed/22.04/",
+            f"rsync://foo.bar/data-feed/{DEFAULT_VERSION}/",
         )
         self.assertEqual(
             values["notus-url"],
-            "rsync://foo.bar/vulnerability-feed/22.04/vt-data/notus/",
+            f"rsync://foo.bar/vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/",
         )
         self.assertEqual(
             values["nasl-url"],
-            "rsync://foo.bar/vulnerability-feed/22.04/vt-data/nasl/",
+            f"rsync://foo.bar/vulnerability-feed/{DEFAULT_VERSION}/vt-data/nasl/",
         )
         self.assertEqual(
             values["scap-data-url"],
-            "rsync://foo.bar/vulnerability-feed/22.04/scap-data/",
+            f"rsync://foo.bar/vulnerability-feed/{DEFAULT_VERSION}/scap-data/",
         )
         self.assertEqual(
             values["cert-data-url"],
-            "rsync://foo.bar/vulnerability-feed/22.04/cert-data/",
+            f"rsync://foo.bar/vulnerability-feed/{DEFAULT_VERSION}/cert-data/",
         )
         self.assertEqual(
             values["report-formats-url"],
-            "rsync://foo.bar/data-feed/22.04/report-formats/",
+            f"rsync://foo.bar/data-feed/{DEFAULT_VERSION}/report-formats/",
         )
         self.assertEqual(
             values["scan-configs-url"],
-            "rsync://foo.bar/data-feed/22.04/scan-configs/",
+            f"rsync://foo.bar/data-feed/{DEFAULT_VERSION}/scan-configs/",
         )
         self.assertEqual(
             values["port-lists-url"],
-            "rsync://foo.bar/data-feed/22.04/port-lists/",
+            f"rsync://foo.bar/data-feed/{DEFAULT_VERSION}/port-lists/",
         )
 
     @patch.dict(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock, call, patch
 
 from pontos.testing import temp_directory
 
+from greenbone.feed.sync.config import DEFAULT_VERSION
 from greenbone.feed.sync.errors import GreenboneFeedSyncError, RsyncError
 from greenbone.feed.sync.main import (
     Sync,
@@ -120,12 +121,12 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
             [
                 call(
                     url="rsync://feed.community.greenbone.net/community/"
-                    "vulnerability-feed/22.04/vt-data/notus/",
+                    f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/",
                     destination=temp_dir / "notus",
                 ),
                 call(
                     url="rsync://feed.community.greenbone.net/community/"
-                    "vulnerability-feed/22.04/vt-data/nasl/",
+                    f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/nasl/",
                     destination=temp_dir / "openvas/plugins",
                 ),
             ]
@@ -177,12 +178,12 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
                 [
                     call(
                         url="rsync://feed.community.greenbone.net/community/"
-                        "vulnerability-feed/22.04/vt-data/notus/",
+                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/",
                         destination=temp_dir / "notus",
                     ),
                     call(
                         url="rsync://feed.community.greenbone.net/community/"
-                        "vulnerability-feed/22.04/vt-data/nasl/",
+                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/nasl/",
                         destination=temp_dir / "openvas/plugins",
                     ),
                 ]
@@ -222,15 +223,15 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
                     call(
                         "Downloading Notus files from "
                         "rsync://feed.community.greenbone.net/community/"
-                        "vulnerability-feed/22.04/vt-data/notus/ to "
-                        f"{temp_dir}/notus"
+                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/ "
+                        f"to {temp_dir}/notus"
                     ),
                     call(),
                     call(
                         "Downloading NASL files from "
                         "rsync://feed.community.greenbone.net/community/"
-                        "vulnerability-feed/22.04/vt-data/nasl/ to "
-                        f"{temp_dir}/openvas/plugins"
+                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/nasl/ "
+                        f"to {temp_dir}/openvas/plugins"
                     ),
                     call(),
                     call(
@@ -244,12 +245,12 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
                 [
                     call(
                         url="rsync://feed.community.greenbone.net/community/"
-                        "vulnerability-feed/22.04/vt-data/notus/",
+                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/",
                         destination=temp_dir / "notus",
                     ),
                     call(
                         url="rsync://feed.community.greenbone.net/community/"
-                        "vulnerability-feed/22.04/vt-data/nasl/",
+                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/nasl/",
                         destination=temp_dir / "openvas/plugins",
                     ),
                 ]
@@ -283,12 +284,12 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
                 [
                     call(
                         url="rsync://feed.community.greenbone.net/community/"
-                        "vulnerability-feed/22.04/vt-data/notus/",
+                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/",
                         destination=temp_dir / "notus",
                     ),
                     call(
                         url="rsync://feed.community.greenbone.net/community/"
-                        "vulnerability-feed/22.04/vt-data/nasl/",
+                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/nasl/",
                         destination=temp_dir / "openvas/plugins",
                     ),
                 ]
@@ -339,7 +340,7 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
                 [
                     call(
                         url="rsync://feed.community.greenbone.net/community/"
-                        "vulnerability-feed/22.04/vt-data/notus/",
+                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/",
                         destination=temp_dir / "notus",
                     ),
                 ]
@@ -396,12 +397,12 @@ class MainFunctionTestCase(unittest.TestCase):
                 [
                     call(
                         url="rsync://feed.community.greenbone.net/community/"
-                        "vulnerability-feed/22.04/vt-data/notus/",
+                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/",
                         destination=temp_dir / "notus",
                     ),
                     call(
                         url="rsync://feed.community.greenbone.net/community/"
-                        "vulnerability-feed/22.04/vt-data/nasl/",
+                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/nasl/",
                         destination=temp_dir / "openvas/plugins",
                     ),
                 ]
@@ -457,7 +458,7 @@ class MainFunctionTestCase(unittest.TestCase):
                 [
                     call(
                         url="rsync://feed.community.greenbone.net/community/"
-                        "vulnerability-feed/22.04/vt-data/notus/",
+                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/",
                         destination=temp_dir / "notus",
                     ),
                 ]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -49,6 +49,7 @@ from greenbone.feed.sync.config import (
     DEFAULT_SCAP_DATA_PATH,
     DEFAULT_SCAP_DATA_URL_PATH,
     DEFAULT_USER_CONFIG_FILE,
+    DEFAULT_VERSION,
 )
 from greenbone.feed.sync.errors import ConfigFileError
 from greenbone.feed.sync.helper import DEFAULT_FLOCK_WAIT_INTERVAL
@@ -742,35 +743,35 @@ sed diam nonumy eirmod tempor
             )
             self.assertEqual(
                 args.gvmd_data_url,
-                "ssh://a_user@some.feed.server/enterprise/data-feed/22.04/",
+                f"ssh://a_user@some.feed.server/enterprise/data-feed/{DEFAULT_VERSION}/",
             )
             self.assertEqual(
                 args.port_lists_url,
-                "ssh://a_user@some.feed.server/enterprise/data-feed/22.04/port-lists/",
+                f"ssh://a_user@some.feed.server/enterprise/data-feed/{DEFAULT_VERSION}/port-lists/",
             )
             self.assertEqual(
                 args.report_formats_url,
-                "ssh://a_user@some.feed.server/enterprise/data-feed/22.04/report-formats/",
+                f"ssh://a_user@some.feed.server/enterprise/data-feed/{DEFAULT_VERSION}/report-formats/",
             )
             self.assertEqual(
                 args.scan_configs_url,
-                "ssh://a_user@some.feed.server/enterprise/data-feed/22.04/scan-configs/",
+                f"ssh://a_user@some.feed.server/enterprise/data-feed/{DEFAULT_VERSION}/scan-configs/",
             )
             self.assertEqual(
                 args.notus_url,
-                "ssh://a_user@some.feed.server/enterprise/vulnerability-feed/22.04/vt-data/notus/",
+                f"ssh://a_user@some.feed.server/enterprise/vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/",
             )
             self.assertEqual(
                 args.nasl_url,
-                "ssh://a_user@some.feed.server/enterprise/vulnerability-feed/22.04/vt-data/nasl/",
+                f"ssh://a_user@some.feed.server/enterprise/vulnerability-feed/{DEFAULT_VERSION}/vt-data/nasl/",
             )
             self.assertEqual(
                 args.scap_data_url,
-                "ssh://a_user@some.feed.server/enterprise/vulnerability-feed/22.04/scap-data/",
+                f"ssh://a_user@some.feed.server/enterprise/vulnerability-feed/{DEFAULT_VERSION}/scap-data/",
             )
             self.assertEqual(
                 args.cert_data_url,
-                "ssh://a_user@some.feed.server/enterprise/vulnerability-feed/22.04/cert-data/",
+                f"ssh://a_user@some.feed.server/enterprise/vulnerability-feed/{DEFAULT_VERSION}/cert-data/",
             )
 
     def test_ignore_non_existing_enterprise_feed_key(self):
@@ -784,35 +785,35 @@ sed diam nonumy eirmod tempor
         )
         self.assertEqual(
             args.gvmd_data_url,
-            "rsync://feed.community.greenbone.net/community/data-feed/22.04/",
+            f"rsync://feed.community.greenbone.net/community/data-feed/{DEFAULT_VERSION}/",
         )
         self.assertEqual(
             args.port_lists_url,
-            "rsync://feed.community.greenbone.net/community/data-feed/22.04/port-lists/",
+            f"rsync://feed.community.greenbone.net/community/data-feed/{DEFAULT_VERSION}/port-lists/",
         )
         self.assertEqual(
             args.report_formats_url,
-            "rsync://feed.community.greenbone.net/community/data-feed/22.04/report-formats/",
+            f"rsync://feed.community.greenbone.net/community/data-feed/{DEFAULT_VERSION}/report-formats/",
         )
         self.assertEqual(
             args.scan_configs_url,
-            "rsync://feed.community.greenbone.net/community/data-feed/22.04/scan-configs/",
+            f"rsync://feed.community.greenbone.net/community/data-feed/{DEFAULT_VERSION}/scan-configs/",
         )
         self.assertEqual(
             args.notus_url,
-            "rsync://feed.community.greenbone.net/community/vulnerability-feed/22.04/vt-data/notus/",
+            f"rsync://feed.community.greenbone.net/community/vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/",
         )
         self.assertEqual(
             args.nasl_url,
-            "rsync://feed.community.greenbone.net/community/vulnerability-feed/22.04/vt-data/nasl/",
+            f"rsync://feed.community.greenbone.net/community/vulnerability-feed/{DEFAULT_VERSION}/vt-data/nasl/",
         )
         self.assertEqual(
             args.scap_data_url,
-            "rsync://feed.community.greenbone.net/community/vulnerability-feed/22.04/scap-data/",
+            f"rsync://feed.community.greenbone.net/community/vulnerability-feed/{DEFAULT_VERSION}/scap-data/",
         )
         self.assertEqual(
             args.cert_data_url,
-            "rsync://feed.community.greenbone.net/community/vulnerability-feed/22.04/cert-data/",
+            f"rsync://feed.community.greenbone.net/community/vulnerability-feed/{DEFAULT_VERSION}/cert-data/",
         )
 
     @patch.object(sys, "argv", ["greenbone-nvt-sync"])


### PR DESCRIPTION
## What

Replace hardcoded version number with a constant.

## Why

Prevent duplicated values in strings.

## References

None.