### PR TITLE
Add: Publish container image for greenbone-feed-sync

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,50 @@
+FROM debian:stable-slim as builder
+
+COPY . /source
+
+WORKDIR /source
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends --no-install-suggests -y \
+    gosu \
+    python3 \
+    python-is-python3 \
+    pipx && \
+    apt-get remove --purge --auto-remove -y && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pipx install poetry
+
+RUN rm -rf dist && /root/.local/bin/poetry build -f wheel
+
+FROM debian:stable-slim
+
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+ENV PIP_NO_CACHE_DIR off
+
+WORKDIR /greenbone-feed-sync
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends --no-install-suggests -y \
+    gosu \
+    rsync \
+    python3 \
+    python3-pip && \
+    apt-get remove --purge --auto-remove -y && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN addgroup --gid 1001 --system gvm && \
+    adduser --no-create-home --shell /bin/false --disabled-password --uid 1001 --system --group gvm
+
+COPY --from=builder /source/dist/* /greenbone-feed-sync/
+COPY .docker/entrypoint.sh /usr/local/bin/entrypoint
+
+RUN python3 -m pip install --break-system-packages /greenbone-feed-sync/*
+
+RUN chown -R gvm:gvm /greenbone-feed-sync && \
+    chmod 755 /usr/local/bin/entrypoint
+
+ENTRYPOINT [ "/usr/local/bin/entrypoint" ]
+
+CMD ["/bin/bash"]

--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec gosu gvm "$@"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.mypy_cache
+.ruff_cache
+.venv
+.vscode
+lib
+htmlcov

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,49 @@
+name: Container Image Builds
+
+on:
+  push:
+    branches: [ main ]
+    tags: ["v*"]
+  workflow_dispatch:
+
+jobs:
+  images:
+    name: Build images
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Login to Dockerhub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Setup container meta information
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ github.repository }}
+          labels: |
+            org.opencontainers.image.vendor=Greenbone
+            org.opencontainers.image.documentation=https://greenbone.github.io/docs/
+            org.opencontainers.image.base.name=debian:stable-slim
+          tags: |
+            # create container tag for git tags
+            type=ref,event=tag
+            # set edge for default branch
+            type=edge
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build and push Container image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          file: .docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION


## What

Publish container image for greenbone-feed-sync

## Why

Build and upload a container image for greenbone-feed-sync to hub.docker.com.



## References

Part 1 to fix https://github.com/greenbone/docs/issues/367

