### PR TITLE
Add: Add bash and zsh completion for greenbone-feed-sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ New script for downloading the Greenbone Community Feed
   - [Install using pip](#install-using-pip)
 - [Usage](#usage)
 - [Usage on Kali Linux](#usage-on-kali-linux)
+- [Command Completion](#command-completion)
 - [Settings](#settings)
   - [verbose](#verbose)
   - [quiet](#quiet)
@@ -137,6 +138,33 @@ This can be done by using a [config file](#config-1).
     group="_gvm"
     EOF
     sudo chmod +r /etc/gvm/greenbone-feed-sync.toml
+
+## Command Completion
+
+`greenbone-feed-sync` comes with support for command line completion in bash
+and zsh.
+
+Setup for bash:
+
+```bash
+echo "source ~/.greenbone-feed-sync-complete.bash" >> ~/.bashrc
+greenbone-feed-sync --print-completion bash > ~/.greenbone-feed-sync-complete.bash
+```
+
+Alternatively, you can use the result of the completion command directly with
+the eval function of your bash shell:
+
+```bash
+eval "$(greenbone-feed-sync --print-completion bash)"
+```
+
+Setup for zsh:
+
+```zsh
+echo 'fpath=("$HOME/.zsh.d" $fpath)' >> ~/.zsh
+mkdir -p ~/.zsh.d/
+greenbone-feed-sync --print-completion zsh > ~/.zsh.d/_greenbone_feed_sync
+```
 
 ## Settings
 

--- a/greenbone/feed/sync/parser.py
+++ b/greenbone/feed/sync/parser.py
@@ -7,6 +7,8 @@ from argparse import ArgumentParser, Namespace
 from pathlib import Path
 from typing import Any, Optional, Sequence
 
+import shtab
+
 from greenbone.feed.sync.__version__ import __version__
 from greenbone.feed.sync.config import (
     DEFAULT_CONFIG_FILE,
@@ -48,6 +50,7 @@ class CliParser:
 
     def __init__(self) -> None:
         parser = ArgumentParser(add_help=False)
+        shtab.add_argument_to(parser)
         parser.add_argument(
             "--version",
             help="Print version then exit.",

--- a/poetry.lock
+++ b/poetry.lock
@@ -694,6 +694,20 @@ files = [
 ]
 
 [[package]]
+name = "shtab"
+version = "1.6.5"
+description = "Automagic shell tab completion for Python CLI applications"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "shtab-1.6.5-py3-none-any.whl", hash = "sha256:3c7be25ab65a324ed41e9c2964f2146236a5da6e6a247355cfea56f65050f220"},
+    {file = "shtab-1.6.5.tar.gz", hash = "sha256:cf4ab120183e84cce041abeb6f620f9560739741dfc31dd466315550c08be9ec"},
+]
+
+[package.extras]
+dev = ["pytest (>=6)", "pytest-cov", "pytest-timeout"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -751,4 +765,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "925e32ab667b7fe929c19c4f304d46000311acda0d2805d9dd27fbba2be7d51c"
+content-hash = "fcb76399a3238b2d08d22b5989b8923506ea2a0375440dfcb1ef7e891ecff9ca"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ packages = [
 python = "^3.9"
 rich = ">=13.2.0"
 tomli = { version = ">=2.0.1", python = "<3.11" }
+shtab = ">=1.6.5"
 
 [tool.poetry.group.dev.dependencies]
 autohooks-plugin-black = ">=22.11.0"


### PR DESCRIPTION


## What

Add bash and zsh completion for greenbone-feed-sync

## Why

Allow to install command completions for bash and zsh. This improves the usability of the tool a lot.


