### PR TITLE
Change: Handle error for missing permission on lock file

### DIFF
--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -140,6 +140,20 @@ class FlockTestCase(unittest.IsolatedAsyncioTestCase):
             ):
                 pass
 
+    async def test_permission_error(self):
+        with temp_directory() as temp_dir:
+            lock_file = temp_dir / "file.lock"
+            lock_file.touch()
+            lock_file.chmod(0)
+            with self.assertRaisesRegex(
+                FileLockingError,
+                f"^Permission error while trying to open the lock file {lock_file.absolute()}$",
+            ):
+                async with flock_wait(
+                    lock_file,
+                ):
+                    pass
+
 
 class SpinnerTestCase(unittest.TestCase):
     @patch("greenbone.feed.sync.helper.Live", autospec=True)


### PR DESCRIPTION


## What

Handle error for missing permission on lock file

## Why

Raise a FileLockingError when the lock file can't be opened due to missing permissions. This will display a better error message and not a full Python traceback.

## References

https://forum.greenbone.net/t/feed-sync-all-falling/17085

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


