### PR TITLE
Added ssh client

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
     gosu \
     python3 \
     python-is-python3 \
+    ssh-client \
     pipx && \
     apt-get remove --purge --auto-remove -y && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION

## What

Install ssh-client package in the container image to allow rsync via ssh.

## Why

This fixes rsync is failing because of missing ssh client. "rsync: [Receiver] Failed to exec ssh: No such file or directory (2)" This fails only while using enterprise feed