### PR TITLE
Fix: uses ruff check

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -19,7 +19,7 @@ jobs:
     uses: greenbone/workflows/.github/workflows/lint-python.yml@main
     with:
       lint-packages: "greenbone tests"
-      linter: ruff
+      linter: ruff check
       python-version: ${{ matrix.python-version }}
 
   test:


### PR DESCRIPTION
## What

Fix: Use ruff check as linter

## Why

Using `ruff` is deprecated ...

## References

[DEVOPS-1093](https://jira.greenbone.net/browse/DEVOPS-1093)