### PR TITLE
Fix: Override default notification-channel

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,4 +25,5 @@ jobs:
         org.opencontainers.image.base.name=debian:stable-slim
       image-url: community/greenbone-feed-sync
       ref-name: ${{ inputs.ref-name }}
+      notification-channel: "pdfeeddeploymentnotification"
     secrets: inherit


### PR DESCRIPTION
## What

Override default notification-channel

## Why

greenbone-feed-sync counts as a feed repo, so it should notify in a different channel.

## References

https://jira.greenbone.net/browse/DEVOPS-1254



