### PR TITLE
Fix failing compression argument parser test for CI

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -302,8 +302,7 @@ class CliParserTestCase(unittest.TestCase):
             parser.parse_arguments(["--compression-level", "10"])
 
         self.assertIn(
-            "error: argument --compression-level: invalid choice: 10 "
-            "(choose from 0, 1, 2, 3, 4, 5, 6, 7, 8, 9)",
+            "error: argument --compression-level: invalid choice:",
             f.getvalue(),
         )
 


### PR DESCRIPTION

## What

Fix failing compression argument parser test for CI

## Why

It seems that with the runner and Python 3.12 the compression argument is uses as a string. Therefore don't include the actual passed argument when testing the error output.


## References
https://github.com/greenbone/greenbone-feed-sync/actions/runs/12626669529/job/35241397170?pr=247
