### PR TITLE
Support feed for 24.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,19 +63,25 @@ within the `PATH`.
 
 On Debian based Distributions like Ubuntu and Kali `rsync` can be installed via
 
-    sudo apt install rsync
+```sh
+sudo apt install rsync
+```
 
 ### Install using pipx
 
 You can install the latest release of **greenbone-feed-sync** from the Python
 Package Index (pypi) using [pipx]
 
-    python3 -m pipx install greenbone-feed-sync
+```sh
+python3 -m pipx install greenbone-feed-sync
+```
 
 On Debian based Distributions like Ubuntu and Kali `pipx` itself can be
 installed via
 
-    sudo apt install pipx
+```sh
+sudo apt install pipx
+```
 
 ### Install using pip
 
@@ -86,7 +92,9 @@ Please use the [installation via pipx](#install-using-pipx) instead.
 You can install the latest release of **greenbone-feed-sync** from the
 Python Package Index ([pypi]) using [pip]
 
-    python3 -m pip install greenbone-feed-sync
+```sh
+python3 -m pip install greenbone-feed-sync
+```
 
 ## Usage
 
@@ -95,27 +103,35 @@ download the new data for all necessary feed types
 
 **NOTE:** See details about [usage on Kali Linux](#usage-on-kali-linux)
 
-    sudo greenbone-feed-sync
+```sh
+sudo greenbone-feed-sync
+```
 
 To get verbose progress output during the data download you might increase the
 verbosity
 
-    sudo greenbone-feed-sync -vvv
-
+```sh
+ sudo greenbone-feed-sync -vvv
+```
 
 If the script is run in a cron job the output can be turned off via
 
-    sudo greenbone-feed-sync --quiet
-
+```sh
+sudo greenbone-feed-sync --quiet
+```
 
 To download only a specific feed content the `--type` argument can be used
 
-    sudo greenbone-feed-sync --type nvt
+```sh
+sudo greenbone-feed-sync --type nvt
+```
 
 Run `--help` to get information about all possible types and additional argument
 options
 
-    greenbone-feed-sync --help
+```sh
+greenbone-feed-sync --help
+````
 
 ## Usage on Kali Linux
 
@@ -131,14 +147,16 @@ a different user and group are used. They are both named `_gvm` instead.
 Therefore the [group](#group) and [user](#user) settings need to be adjusted.
 This can be done by using a [config file](#config-1).
 
-    sudo mkdir /etc/gvm
-    sudo chmod +r /etc/gvm
-    cat <<EOF | sudo tee /etc/gvm/greenbone-feed-sync.toml
-    [greenbone-feed-sync]
-    user="_gvm"
-    group="_gvm"
-    EOF
-    sudo chmod +r /etc/gvm/greenbone-feed-sync.toml
+```sh
+sudo mkdir /etc/gvm
+sudo chmod +r /etc/gvm
+cat <<EOF | sudo tee /etc/gvm/greenbone-feed-sync.toml
+[greenbone-feed-sync]
+user="_gvm"
+group="_gvm"
+EOF
+sudo chmod +r /etc/gvm/greenbone-feed-sync.toml
+```
 
 ## Command Completion
 
@@ -538,11 +556,15 @@ build process.
 
 First install poetry via pipx
 
-    python3 -m pipx install poetry
+```sh
+python3 -m pipx install poetry
+```
 
 Afterwards run
 
-    poetry install
+```sh
+poetry install
+```
 
 in the checkout directory of **greenbone-feed-sync** (the directory containing
 the `pyproject.toml` file) to install all dependencies including the packages
@@ -551,11 +573,15 @@ only required for development.
 Afterwards activate the git hooks for auto-formatting and linting via
 [autohooks].
 
-    poetry run autohooks activate
+```sh
+poetry run autohooks activate
+```
 
 Validate the activated git hooks by running
 
-    poetry run autohooks check
+```sh
+poetry run autohooks check
+```
 
 ## Maintainer
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 # greenbone-feed-sync <!-- omit in toc -->
 
-New script for downloading the Greenbone Community Feed
+Tool for downloading the Greenbone Community Feed.
+
+`greenbone-feed-sync` assumes you are using the latest feed version and up to
+date components of the Greenbone Community Edition by default. It is highly
+configurable and can be adjusted easily for downloading different feed versions.
 
 - [Installation](#installation)
   - [Requirements](#requirements)

--- a/README.md
+++ b/README.md
@@ -278,12 +278,12 @@ is only required for experts and testing purposes.
 
 ### destination-prefix
 
-| Name                 | Value                                                                                                                                                                                                                                                               |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CLI Argument         |                                                                                                                                                                                                                                                                     |
-| Config Variable      | destination-prefix                                                                                                                                                                                                                                                  |
-| Environment Variable | `GREENBONE_FEED_SYNC_DESTINATION_PREFIX`                                                                                                                                                                                                                            |
-| Default Value        | `/var/lib/`                                                                                                                                                                                                                                                         |
+| Name                 | Value                                    |
+| -------------------- | ---------------------------------------- |
+| CLI Argument         | `--destination-prefix`                   |
+| Config Variable      | destination-prefix                       |
+| Environment Variable | `GREENBONE_FEED_SYNC_DESTINATION_PREFIX` |
+| Default Value        | `/var/lib/`                              |
 | Description          | Directory prefix to use for default feed data download destinations. Other download destinations will be relative to this path by default. For example using `/opt/lib` as destination prefix will change the default of the notus destination to `/opt/lib/notus`. |
 
 ### gvmd-data-destination
@@ -318,7 +318,7 @@ is only required for experts and testing purposes.
 
 ### notus-url
 
-| Name                 | Value                                                                                    |
+| Name                 | Value                                                       |
 | -------------------- | ------------------------------------------------------------|
 | CLI Argument         | `--notus-url`                                               |
 | Config Variable      | notus-url                                                   |
@@ -338,7 +338,7 @@ is only required for experts and testing purposes.
 
 ### nasl-url
 
-| Name                 | Value                                                                                   |
+| Name                 | Value                                                      |
 | -------------------- | -----------------------------------------------------------|
 | CLI Argument         | `--nasl-url`                                               |
 | Config Variable      | nasl-url                                                   |

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ is only required for experts and testing purposes.
 | Config Variable      | feed-url                                                                                                                                                                                                                         |
 | Environment Variable | `GREENBONE_FEED_SYNC_URL`                                                                                                                                                                                                        |
 | Default Value        | `rsync://feed.community.greenbone.net/community`                                                                                                                                                                                 |
-| Description          | URL to download the feed data from. Other URLs will be relative to this URL by default. For example using `rsync://example.com` as feed url the notus url will be `rsync://example.com/vulnerability-feed/22.04/vt-data/notus/`. |
+| Description          | URL to download the feed data from. Other URLs will be relative to this URL by default. For example using `rsync://example.com` as feed url the notus url will be `rsync://example.com/vulnerability-feed/$FEED_VERSION/vt-data/notus/`. |
 
 ### feed-version
 
@@ -270,7 +270,7 @@ is only required for experts and testing purposes.
 | Config Variable      | feed-version                          |
 | Environment Variable | `GREENBONE_FEED_SYNC_FEED_VERSION`    |
 | Default Value        | `22.04`                               |
-| Description          | Version of the feed to be downloaded. |
+| Description          | Version of the feed to be downloaded. Download destinations and URLs will use this variable. |
 
 ### destination-prefix
 
@@ -284,13 +284,13 @@ is only required for experts and testing purposes.
 
 ### gvmd-data-destination
 
-| Name                 | Value                                       |
-| -------------------- | ------------------------------------------- |
-| CLI Argument         | `--gvmd-data-destination`                   |
-| Config Variable      | gvmd-data-destination                       |
-| Environment Variable | `GREENBONE_FEED_SYNC_GVMD_DATA_DESTINATION` |
-| Default Value        | `/var/lib/gvm/data-objects/gvmd/22.04/`     |
-| Description          | Destination of the downloaded gvmd data.    |
+| Name                 | Value                                                      |
+| -------------------- | ---------------------------------------------------------- |
+| CLI Argument         | `--gvmd-data-destination`                                  |
+| Config Variable      | gvmd-data-destination                                      |
+| Environment Variable | `GREENBONE_FEED_SYNC_GVMD_DATA_DESTINATION`                |
+| Default Value        | `$DESTINATION_PREFIX/gvm/data-objects/gvmd/$FEED_VERSION/` |
+| Description          | Destination of the downloaded gvmd data.                   |
 
 ### gvmd-data-url
 
@@ -299,7 +299,7 @@ is only required for experts and testing purposes.
 | CLI Argument         | `--gvmd-data-url`                                                                              |
 | Config Variable      | gvmd-data-url                                                                                  |
 | Environment Variable | `GREENBONE_FEED_SYNC_GVMD_DATA_URL`                                                            |
-| Default Value        | `rsync://feed.community.greenbone.net/community/data-feed/22.04/`                              |
+| Default Value        | `$FEED_URL/data-feed/$FEED_VERSION/`                                                           |
 | Description          | URL to download the gvmd data from. This includes scan-configs, report-formats and port-lists. |
 
 ### notus-destination
@@ -309,18 +309,18 @@ is only required for experts and testing purposes.
 | CLI Argument         | `--notus-destination`                     |
 | Config Variable      | notus-destination                         |
 | Environment Variable | `GREENBONE_FEED_SYNC_NOTUS_DESTINATION`   |
-| Default Value        | `/var/lib/notus`                          |
+| Default Value        | `$DESTINATION_PREFIX/notus`               |
 | Description          | Destination of the downloaded notus data. |
 
 ### notus-url
 
 | Name                 | Value                                                                                    |
-| -------------------- | ---------------------------------------------------------------------------------------- |
-| CLI Argument         | `--notus-url`                                                                            |
-| Config Variable      | notus-url                                                                                |
-| Environment Variable | `GREENBONE_FEED_SYNC_NOTUS_URL`                                                          |
-| Default Value        | `rsync://feed.community.greenbone.net/community/vulnerability-feed/22.04/vt-data/notus/` |
-| Description          | URL to download the notus data from.                                                     |
+| -------------------- | ------------------------------------------------------------|
+| CLI Argument         | `--notus-url`                                               |
+| Config Variable      | notus-url                                                   |
+| Environment Variable | `GREENBONE_FEED_SYNC_NOTUS_URL`                             |
+| Default Value        | `$FEED_URL/vulnerability-feed/$FEED_VERSION/vt-data/notus/` |
+| Description          | URL to download the notus data from.                        |
 
 ### nasl-destination
 
@@ -329,18 +329,18 @@ is only required for experts and testing purposes.
 | CLI Argument         | `--nasl-destination`                     |
 | Config Variable      | nasl-destination                         |
 | Environment Variable | `GREENBONE_FEED_SYNC_NASL_DESTINATION`   |
-| Default Value        | `/var/lib/openvas/plugins`               |
+| Default Value        | `$DESTINATION_PREFIX/openvas/plugins`    |
 | Description          | Destination of the downloaded nasl data. |
 
 ### nasl-url
 
 | Name                 | Value                                                                                   |
-| -------------------- | --------------------------------------------------------------------------------------- |
-| CLI Argument         | `--nasl-url`                                                                            |
-| Config Variable      | nasl-url                                                                                |
-| Environment Variable | `GREENBONE_FEED_SYNC_NASL_URL`                                                          |
-| Default Value        | `rsync://feed.community.greenbone.net/community/vulnerability-feed/22.04/vt-data/nasl/` |
-| Description          | URL to download the nasl data from.                                                     |
+| -------------------- | -----------------------------------------------------------|
+| CLI Argument         | `--nasl-url`                                               |
+| Config Variable      | nasl-url                                                   |
+| Environment Variable | `GREENBONE_FEED_SYNC_NASL_URL`                             |
+| Default Value        | `$FEED_URL/vulnerability-feed/$FEED_VERSION/vt-data/nasl/` |
+| Description          | URL to download the nasl data from.                        |
 
 ### scap-data-destination
 
@@ -349,18 +349,18 @@ is only required for experts and testing purposes.
 | CLI Argument         | `--scap-data-destination`                   |
 | Config Variable      | scap-data-destination                       |
 | Environment Variable | `GREENBONE_FEED_SYNC_SCAP_DATA_DESTINATION` |
-| Default Value        | `/var/lib/gvm/scap-data`                    |
+| Default Value        | `$DESTINATION_PREFIX/gvm/scap-data`         |
 | Description          | Destination of the downloaded SCAP data.    |
 
 ### scap-data-url
 
-| Name                 | Value                                                                               |
-| -------------------- | ----------------------------------------------------------------------------------- |
-| CLI Argument         | `--scap-data-url`                                                                   |
-| Config Variable      | scap-data-url                                                                       |
-| Environment Variable | `GREENBONE_FEED_SYNC_SCAP_DATA_URL`                                                 |
-| Default Value        | `rsync://feed.community.greenbone.net/community/vulnerability-feed/22.04/scap-data` |
-| Description          | URL to download the SCAP data from.                                                 |
+| Name                 | Value                                                  |
+| -------------------- | -------------------------------------------------------|
+| CLI Argument         | `--scap-data-url`                                      |
+| Config Variable      | scap-data-url                                          |
+| Environment Variable | `GREENBONE_FEED_SYNC_SCAP_DATA_URL`                    |
+| Default Value        | `$FEED_URL/vulnerability-feed/$FEED_VERSION/scap-data` |
+| Description          | URL to download the SCAP data from.                    |
 
 ### cert-data-destination
 
@@ -369,97 +369,97 @@ is only required for experts and testing purposes.
 | CLI Argument         | `--cert-data-destination`                   |
 | Config Variable      | cert-data-destination                       |
 | Environment Variable | `GREENBONE_FEED_SYNC_CERT_DATA_DESTINATION` |
-| Default Value        | `/var/lib/gvm/cert-data`                    |
+| Default Value        | `$DESTINATION_PREFIX/gvm/cert-data`         |
 | Description          | Destination of the downloaded CERT data.    |
 
 ### cert-data-url
 
-| Name                 | Value                                                                               |
-| -------------------- | ----------------------------------------------------------------------------------- |
-| CLI Argument         | `--cert-data-url`                                                                   |
-| Config Variable      | cert-data-url                                                                       |
-| Environment Variable | `GREENBONE_FEED_SYNC_CERT_DATA_URL`                                                 |
-| Default Value        | `rsync://feed.community.greenbone.net/community/vulnerability-feed/22.04/cert-data` |
-| Description          | URL to download the CERT data from.                                                 |
+| Name                 | Value                                                  |
+| -------------------- | -------------------------------------------------------|
+| CLI Argument         | `--cert-data-url`                                      |
+| Config Variable      | cert-data-url                                          |
+| Environment Variable | `GREENBONE_FEED_SYNC_CERT_DATA_URL`                    |
+| Default Value        | `$FEED_URL/vulnerability-feed/$FEED_VERSION/cert-data` |
+| Description          | URL to download the CERT data from.                    |
 
 ### report-formats-destination
 
-| Name                 | Value                                                 |
-| -------------------- | ----------------------------------------------------- |
-| CLI Argument         | `--report-formats-destination`                        |
-| Config Variable      | report-formats-destination                            |
-| Environment Variable | `GREENBONE_FEED_SYNC_REPORT_FORMATS_DESTINATION`      |
-| Default Value        | `/var/lib/gvm/data-objects/gvmd/22.04/report-formats` |
-| Description          | Destination of the downloaded report format data.     |
+| Name                 | Value                                                                    |
+| -------------------- | ------------------------------------------------------------------------ |
+| CLI Argument         | `--report-formats-destination`                                           |
+| Config Variable      | report-formats-destination                                               |
+| Environment Variable | `GREENBONE_FEED_SYNC_REPORT_FORMATS_DESTINATION`                         |
+| Default Value        | `$DESTINATION_PREFIX/gvm/data-objects/gvmd/$FEED_VERSION/report-formats` |
+| Description          | Destination of the downloaded report format data.                        |
 
 ### report-formats-url
 
-| Name                 | Value                                                                           |
-| -------------------- | ------------------------------------------------------------------------------- |
-| CLI Argument         | `--report-formats-url`                                                          |
-| Config Variable      | report-formats-url                                                              |
-| Environment Variable | `GREENBONE_FEED_SYNC_REPORT_FORMATS_URL`                                        |
-| Default Value        | `rsync://feed.community.greenbone.net/community/data-feed/22.04/report-formats` |
-| Description          | URL to download the report format data from.                                    |
+| Name                 | Value                                              |
+| -------------------- | ---------------------------------------------------|
+| CLI Argument         | `--report-formats-url`                             |
+| Config Variable      | report-formats-url                                 |
+| Environment Variable | `GREENBONE_FEED_SYNC_REPORT_FORMATS_URL`           |
+| Default Value        | `$FEED_URL/data-feed/$FEED_VERSION/report-formats` |
+| Description          | URL to download the report format data from.       |
 
 ### scan-configs-destination
 
-| Name                 | Value                                               |
-| -------------------- | --------------------------------------------------- |
-| CLI Argument         | `--scan-configs-destination`                        |
-| Config Variable      | scan-configs-destination                            |
-| Environment Variable | `GREENBONE_FEED_SYNC_SCAN_CONFIGS_DESTINATION`      |
-| Default Value        | `/var/lib/gvm/data-objects/gvmd/22.04/scan-configs` |
-| Description          | Destination of the downloaded scan config data.     |
+| Name                 | Value                                                                  |
+| -------------------- | ---------------------------------------------------------------------- |
+| CLI Argument         | `--scan-configs-destination`                                           |
+| Config Variable      | scan-configs-destination                                               |
+| Environment Variable | `GREENBONE_FEED_SYNC_SCAN_CONFIGS_DESTINATION`                         |
+| Default Value        | `$DESTINATION_PREFIX/gvm/data-objects/gvmd/$FEED_VERSION/scan-configs` |
+| Description          | Destination of the downloaded scan config data.                        |
 
 ### scan-configs-url
 
 | Name                 | Value                                                                         |
-| -------------------- | ----------------------------------------------------------------------------- |
-| CLI Argument         | `--scan-configs-url`                                                          |
-| Config Variable      | scan-configs-url                                                              |
-| Environment Variable | `GREENBONE_FEED_SYNC_SCAN_CONFIGS_URL`                                        |
-| Default Value        | `rsync://feed.community.greenbone.net/community/data-feed/22.04/scan-configs` |
-| Description          | URL to download the scan config data from.                                    |
+| -------------------- | -------------------------------------------------|
+| CLI Argument         | `--scan-configs-url`                             |
+| Config Variable      | scan-configs-url                                 |
+| Environment Variable | `GREENBONE_FEED_SYNC_SCAN_CONFIGS_URL`           |
+| Default Value        | `$FEED_URL/data-feed/$FEED_VERSION/scan-configs` |
+| Description          | URL to download the scan config data from.       |
 
 ### port-lists-destination
 
-| Name                 | Value                                             |
-| -------------------- | ------------------------------------------------- |
-| CLI Argument         | `--port-lists-destination`                        |
-| Config Variable      | port-lists-destination                            |
-| Environment Variable | `GREENBONE_FEED_SYNC_PORT_LISTS_DESTINATION`      |
-| Default Value        | `/var/lib/gvm/data-objects/gvmd/22.04/port-lists` |
-| Description          | Destination of the downloaded port list data.     |
+| Name                 | Value                                                                |
+| -------------------- | -------------------------------------------------------------------- |
+| CLI Argument         | `--port-lists-destination`                                           |
+| Config Variable      | port-lists-destination                                               |
+| Environment Variable | `GREENBONE_FEED_SYNC_PORT_LISTS_DESTINATION`                         |
+| Default Value        | `$DESTINATION_PREFIX/gvm/data-objects/gvmd/$FEED_VERSION/port-lists` |
+| Description          | Destination of the downloaded port list data.                        |
 
 ### port-lists-url
 
-| Name                 | Value                                                                       |
-| -------------------- | --------------------------------------------------------------------------- |
-| CLI Argument         | `--port-lists-url`                                                          |
-| Config Variable      | port-lists-url                                                              |
-| Environment Variable | `GREENBONE_FEED_SYNC_PORT_LISTS_URL`                                        |
-| Default Value        | `rsync://feed.community.greenbone.net/community/data-feed/22.04/port-lists` |
-| Description          | URL to download the port list data from.                                    |
+| Name                 | Value                                          |
+| -------------------- | -----------------------------------------------|
+| CLI Argument         | `--port-lists-url`                             |
+| Config Variable      | port-lists-url                                 |
+| Environment Variable | `GREENBONE_FEED_SYNC_PORT_LISTS_URL`           |
+| Default Value        | `$FEED_URL/data-feed/$FEED_VERSION/port-lists` |
+| Description          | URL to download the port list data from.       |
 
 ### gvmd-lock-file
 
-| Name                 | Value                                                                                                                                                                  |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CLI Argument         | `--gvmd-lock-file`                                                                                                                                                     |
-| Config Variable      | gvmd-lock-file                                                                                                                                                         |
-| Environment Variable | `GREENBONE_FEED_SYNC_GVMD_LOCK_FILE`                                                                                                                                   |
-| Default Value        | `/var/lib/gvm/feed-update.lock`                                                                                                                                        |
+| Name                 | Value                                      |
+| -------------------- | ------------------------------------------ |
+| CLI Argument         | `--gvmd-lock-file`                         |
+| Config Variable      | gvmd-lock-file                             |
+| Environment Variable | `GREENBONE_FEED_SYNC_GVMD_LOCK_FILE`       |
+| Default Value        | `$DESTINATION_PREFIX/gvm/feed-update.lock` |
 | Description          | File to use for locking the feed synchronization for data loaded by the gvmd daemon. Used to avoid that more then one process accesses the feed data at the same time. |
 
 ### openvas-lock-file
 
-| Name                 | Value                                                                                                                                                                      |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CLI Argument         | `--openvas-lock-file`                                                                                                                                                      |
-| Config Variable      | openvas-lock-file                                                                                                                                                          |
-| Environment Variable | `GREENBONE_FEED_SYNC_OPENVAS_LOCK_FILE`                                                                                                                                    |
-| Default Value        | `/var/lib/openvas/feed-update.lock`                                                                                                                                        |
+| Name                 | Value                                          |
+| -------------------- | ---------------------------------------------- |
+| CLI Argument         | `--openvas-lock-file`                          |
+| Config Variable      | openvas-lock-file                              |
+| Environment Variable | `GREENBONE_FEED_SYNC_OPENVAS_LOCK_FILE`        |
+| Default Value        | `$DESTINATION_PREFIX/openvas/feed-update.lock` |
 | Description          | File to use for locking the feed synchronization for data loaded by the openvas scanner. Used to avoid that more then one process accesses the feed data at the same time. |
 
 ### fail-fast
@@ -494,12 +494,12 @@ is only required for experts and testing purposes.
 
 ### rsync-timeout
 
-| Name                 | Value                                                                                                                                                                                  |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CLI Argument         | `--rsync-timeout`                                                                                                                                                                      |
-| Config Variable      | rsync-timeout                                                                                                                                                                          |
-| Environment Variable | `GREENBONE_FEED_SYNC_RSYNC_TIMEOUT`                                                                                                                                                    |
-| Default Value        |                                                                                                                                                                                        |
+| Name                 | Value                               |
+| -------------------- | ----------------------------------- |
+| CLI Argument         | `--rsync-timeout`                   |
+| Config Variable      | rsync-timeout                       |
+| Environment Variable | `GREENBONE_FEED_SYNC_RSYNC_TIMEOUT` |
+| Default Value        |                                     |
 | Description          | Maximum I/O timeout in seconds used for rsync. If no data is transferred for the specified time then rsync will exit. By default no timeout is set and the rsync default will be used. |
 
 ### group
@@ -524,12 +524,12 @@ is only required for experts and testing purposes.
 
 ### greenbone-enterprise-feed-key
 
-| Name                 | Value                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CLI Argument         | `--greenbone-enterprise-feed-key`                                                                                                                                                                                                                                                                                                                                                                                     |
-| Config Variable      | greenbone-enterprise-feed-key                                                                                                                                                                                                                                                                                                                                                                                         |
-| Environment Variable | `GREENBONE_FEED_SYNC_ENTERPRISE_FEED_KEY`                                                                                                                                                                                                                                                                                                                                                                             |
-| Default Value        | /etc/gvm/greenbone-enterprise-feed-key                                                                                                                                                                                                                                                                                                                                                                                |
+| Name                 | Value                                     |
+| -------------------- | ----------------------------------------- |
+| CLI Argument         | `--greenbone-enterprise-feed-key`         |
+| Config Variable      | greenbone-enterprise-feed-key             |
+| Environment Variable | `GREENBONE_FEED_SYNC_ENTERPRISE_FEED_KEY` |
+| Default Value        | /etc/gvm/greenbone-enterprise-feed-key    |
 | Description          | File to read the Greenbone Enterprise Feed key from. The key gives access to additional vulnerability tests for enterprise software among other advantages. See [Greenbone Enterprise Feed and Greenbone Community Feed in Comparison](https://www.greenbone.net/en/feed-comparison/) for more details. The default URLs are adjusted according to the data in the key. If the key file does not exist it is ignored. |
 
 ## Config

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ New script for downloading the Greenbone Community Feed
   - [compression-level](#compression-level)
   - [type](#type)
   - [feed-url](#feed-url)
+  - [feed-version](#feed-version)
   - [destination-prefix](#destination-prefix)
   - [gvmd-data-destination](#gvmd-data-destination)
   - [gvmd-data-url](#gvmd-data-url)
@@ -242,6 +243,16 @@ is only required for experts and testing purposes.
 | Environment Variable | `GREENBONE_FEED_SYNC_URL`                                                                                                                                                                                                        |
 | Default Value        | `rsync://feed.community.greenbone.net/community`                                                                                                                                                                                 |
 | Description          | URL to download the feed data from. Other URLs will be relative to this URL by default. For example using `rsync://example.com` as feed url the notus url will be `rsync://example.com/vulnerability-feed/22.04/vt-data/notus/`. |
+
+### feed-version
+
+| Name                 |                                       |
+| -------------------- |---------------------------------------|
+| CLI Argument         | `--feed-version`                      |
+| Config Variable      | feed-version                          |
+| Environment Variable | `GREENBONE_FEED_SYNC_FEED_VERSION`    |
+| Default Value        | `22.04`                               |
+| Description          | Version of the feed to be downloaded. |
 
 ### destination-prefix
 

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ is only required for experts and testing purposes.
 | CLI Argument         | `--feed-version`                      |
 | Config Variable      | feed-version                          |
 | Environment Variable | `GREENBONE_FEED_SYNC_FEED_VERSION`    |
-| Default Value        | `22.04`                               |
+| Default Value        | `24.10`                               |
 | Description          | Version of the feed to be downloaded. Download destinations and URLs will use this variable. |
 
 ### destination-prefix

--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ first.
 
 ## License
 
-Copyright (C) 2022-2024 [Greenbone AG][Greenbone Networks]
+Copyright (C) 2022-2025 [Greenbone AG][Greenbone Networks]
 
 Licensed under the [GNU General Public License v3.0 or later](LICENSE).
 

--- a/greenbone/feed/sync/config.py
+++ b/greenbone/feed/sync/config.py
@@ -34,18 +34,7 @@ def maybe_int(value: Optional[str]) -> Union[int, str, None]:
     return value
 
 
-DEFAULT_VERSION = "22.04"
-
-DEFAULT_NOTUS_URL_PATH = f"/vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/"
-DEFAULT_NASL_URL_PATH = f"/vulnerability-feed/{DEFAULT_VERSION}/vt-data/nasl/"
-DEFAULT_SCAP_DATA_URL_PATH = f"/vulnerability-feed/{DEFAULT_VERSION}/scap-data/"
-DEFAULT_CERT_DATA_URL_PATH = f"/vulnerability-feed/{DEFAULT_VERSION}/cert-data/"
-DEFAULT_GVMD_DATA_URL_PATH = f"/data-feed/{DEFAULT_VERSION}/"
-DEFAULT_REPORT_FORMATS_URL_PATH = (
-    f"/data-feed/{DEFAULT_VERSION}/report-formats/"
-)
-DEFAULT_SCAN_CONFIGS_URL_PATH = f"/data-feed/{DEFAULT_VERSION}/scan-configs/"
-DEFAULT_PORT_LISTS_URL_PATH = f"/data-feed/{DEFAULT_VERSION}/port-lists/"
+DEFAULT_FEED_VERSION = "22.04"
 
 DEFAULT_DESTINATION_PREFIX = "/var/lib/"
 
@@ -53,14 +42,6 @@ DEFAULT_NASL_PATH = "openvas/plugins"
 DEFAULT_NOTUS_PATH = "notus"
 DEFAULT_SCAP_DATA_PATH = "gvm/scap-data"
 DEFAULT_CERT_DATA_PATH = "gvm/cert-data"
-DEFAULT_GVMD_DATA_PATH = f"gvm/data-objects/gvmd/{DEFAULT_VERSION}/"
-DEFAULT_REPORT_FORMATS_PATH = (
-    f"gvm/data-objects/gvmd/{DEFAULT_VERSION}/report-formats"
-)
-DEFAULT_SCAN_CONFIGS_PATH = (
-    f"gvm/data-objects/gvmd/{DEFAULT_VERSION}/scan-configs"
-)
-DEFAULT_PORT_LISTS_PATH = f"gvm/data-objects/gvmd/{DEFAULT_VERSION}/port-lists"
 
 DEFAULT_GVMD_LOCK_FILE_PATH = "gvm/feed-update.lock"
 DEFAULT_OPENVAS_LOCK_FILE_PATH = "openvas/feed-update.lock"
@@ -171,6 +152,12 @@ _SETTINGS = (
         DEFAULT_ENTERPRISE_KEY_PATH,
         Path,
     ),
+    Setting(
+        "feed-version",
+        "GREENBONE_FEED_SYNC_FEED_VERSION",
+        DEFAULT_FEED_VERSION,
+        str,
+    ),
 )
 
 # pylint: disable=line-too-long
@@ -178,13 +165,13 @@ _DEPENDENT_SETTINGS = (
     DependentSetting(
         "gvmd-data-destination",
         "GREENBONE_FEED_SYNC_GVMD_DATA_DESTINATION",
-        lambda values: f"{values['destination-prefix']}/{DEFAULT_GVMD_DATA_PATH}",  # noqa: E501
+        lambda values: f"{values['destination-prefix']}/gvm/data-objects/gvmd/{values['feed-version']}/",  # noqa: E501
         Path,
     ),
     DependentSetting(
         "gvmd-data-url",
         "GREENBONE_FEED_SYNC_GVMD_DATA_URL",
-        lambda values: f"{values['feed-url']}{DEFAULT_GVMD_DATA_URL_PATH}",
+        lambda values: f"{values['feed-url']}/data-feed/{values['feed-version']}/",
         str,
     ),
     DependentSetting(
@@ -196,7 +183,7 @@ _DEPENDENT_SETTINGS = (
     DependentSetting(
         "notus-url",
         "GREENBONE_FEED_SYNC_NOTUS_URL",
-        lambda values: f"{values['feed-url']}{DEFAULT_NOTUS_URL_PATH}",
+        lambda values: f"{values['feed-url']}/vulnerability-feed/{values['feed-version']}/vt-data/notus/",
         str,
     ),
     DependentSetting(
@@ -208,7 +195,7 @@ _DEPENDENT_SETTINGS = (
     DependentSetting(
         "nasl-url",
         "GREENBONE_FEED_SYNC_NASL_URL",
-        lambda values: f"{values['feed-url']}{DEFAULT_NASL_URL_PATH}",
+        lambda values: f"{values['feed-url']}/vulnerability-feed/{values['feed-version']}/vt-data/nasl/",
         str,
     ),
     DependentSetting(
@@ -220,7 +207,7 @@ _DEPENDENT_SETTINGS = (
     DependentSetting(
         "scap-data-url",
         "GREENBONE_FEED_SYNC_SCAP_DATA_URL",
-        lambda values: f"{values['feed-url']}{DEFAULT_SCAP_DATA_URL_PATH}",
+        lambda values: f"{values['feed-url']}/vulnerability-feed/{values['feed-version']}/scap-data/",
         str,
     ),
     DependentSetting(
@@ -232,43 +219,43 @@ _DEPENDENT_SETTINGS = (
     DependentSetting(
         "cert-data-url",
         "GREENBONE_FEED_SYNC_CERT_DATA_URL",
-        lambda values: f"{values['feed-url']}{DEFAULT_CERT_DATA_URL_PATH}",
+        lambda values: f"{values['feed-url']}/vulnerability-feed/{values['feed-version']}/cert-data/",
         str,
     ),
     DependentSetting(
         "report-formats-destination",
         "GREENBONE_FEED_SYNC_REPORT_FORMATS_DESTINATION",
-        lambda values: f"{values['destination-prefix']}/{DEFAULT_REPORT_FORMATS_PATH}",  # noqa: E501
+        lambda values: f"{values['destination-prefix']}/gvm/data-objects/gvmd/{values['feed-version']}/report-formats",  # noqa: E501
         Path,
     ),
     DependentSetting(
         "report-formats-url",
         "GREENBONE_FEED_SYNC_REPORT_FORMATS_URL",
-        lambda values: f"{values['feed-url']}{DEFAULT_REPORT_FORMATS_URL_PATH}",  # noqa: E501
+        lambda values: f"{values['feed-url']}/data-feed/{values['feed-version']}/report-formats/",  # noqa: E501
         str,
     ),
     DependentSetting(
         "scan-configs-destination",
         "GREENBONE_FEED_SYNC_SCAN_CONFIGS_DESTINATION",
-        lambda values: f"{values['destination-prefix']}/{DEFAULT_SCAN_CONFIGS_PATH}",  # noqa: E501
+        lambda values: f"{values['destination-prefix']}/gvm/data-objects/gvmd/{values['feed-version']}/scan-configs",  # noqa: E501
         Path,
     ),
     DependentSetting(
         "scan-configs-url",
         "GREENBONE_FEED_SYNC_SCAN_CONFIGS_URL",
-        lambda values: f"{values['feed-url']}{DEFAULT_SCAN_CONFIGS_URL_PATH}",
+        lambda values: f"{values['feed-url']}/data-feed/{values['feed-version']}/scan-configs/",  # noqa: E501
         str,
     ),
     DependentSetting(
         "port-lists-destination",
         "GREENBONE_FEED_SYNC_PORT_LISTS_DESTINATION",
-        lambda values: f"{values['destination-prefix']}/{DEFAULT_PORT_LISTS_PATH}",  # noqa: E501
+        lambda values: f"{values['destination-prefix']}/gvm/data-objects/gvmd/{values['feed-version']}/port-lists",  # noqa: E501
         Path,
     ),
     DependentSetting(
         "port-lists-url",
         "GREENBONE_FEED_SYNC_PORT_LISTS_URL",
-        lambda values: f"{values['feed-url']}{DEFAULT_PORT_LISTS_URL_PATH}",
+        lambda values: f"{values['feed-url']}/data-feed/{values['feed-version']}/port-lists/",  # noqa: E501
         str,
     ),
     DependentSetting(

--- a/greenbone/feed/sync/config.py
+++ b/greenbone/feed/sync/config.py
@@ -34,7 +34,7 @@ def maybe_int(value: Optional[str]) -> Union[int, str, None]:
     return value
 
 
-DEFAULT_FEED_VERSION = "22.04"
+DEFAULT_FEED_VERSION = "24.10"
 
 DEFAULT_DESTINATION_PREFIX = "/var/lib/"
 

--- a/greenbone/feed/sync/parser.py
+++ b/greenbone/feed/sync/parser.py
@@ -118,6 +118,10 @@ class CliParser:
             help="Select which feed should be synced. (Default: %(default)s)",
         )
         parser.add_argument(
+            "--feed-version",
+            help="Version of the Feed to download. (Default: %(default)s)",
+        )
+        parser.add_argument(
             "--gvmd-data-destination",
             type=Path,
             help="Destination of the downloaded gvmd data. "
@@ -125,8 +129,7 @@ class CliParser:
         )
         parser.add_argument(
             "--gvmd-data-url",
-            help="URL to download the gvmd data from. "
-            "(Default: %(default)s)",
+            help="URL to download the gvmd data from. (Default: %(default)s)",
         )
         nvts_destination_group = parser.add_argument_group()
         nvts_destination_group.add_argument(
@@ -138,8 +141,7 @@ class CliParser:
         nvts_url_group = parser.add_argument_group()
         nvts_url_group.add_argument(
             "--notus-url",
-            help="URL to download the notus data from. "
-            "(Default: %(default)s)",
+            help="URL to download the notus data from. (Default: %(default)s)",
         )
         nvts_destination_group.add_argument(
             "--nasl-destination",
@@ -149,8 +151,7 @@ class CliParser:
         )
         nvts_url_group.add_argument(
             "--nasl-url",
-            help="URL to download the nasl data from. "
-            "(Default: %(default)s)",
+            help="URL to download the nasl data from. (Default: %(default)s)",
         )
 
         secinfo_destination_group = parser.add_argument_group()
@@ -163,8 +164,7 @@ class CliParser:
         secinfo_url_group = parser.add_argument_group()
         secinfo_url_group.add_argument(
             "--scap-data-url",
-            help="URL to download the SCAP data from. "
-            "(Default: %(default)s)",
+            help="URL to download the SCAP data from. (Default: %(default)s)",
         )
         secinfo_destination_group.add_argument(
             "--cert-data-destination",
@@ -174,8 +174,7 @@ class CliParser:
         )
         secinfo_url_group.add_argument(
             "--cert-data-url",
-            help="URL to download the CERT data from. "
-            "(Default: %(default)s)",
+            help="URL to download the CERT data from. (Default: %(default)s)",
         )
 
         data_objects_destination_group = parser.add_argument_group()
@@ -341,6 +340,9 @@ class CliParser:
             config["greenbone-enterprise-feed-key"] = (
                 known_args.greenbone_enterprise_feed_key
             )
+
+        if known_args.feed_version:
+            config["feed-version"] = known_args.feed_version
 
         if self.parser.prog == "greenbone-nvt-sync":
             config["type"] = "nvt"

--- a/greenbone/feed/sync/parser.py
+++ b/greenbone/feed/sync/parser.py
@@ -122,6 +122,11 @@ class CliParser:
             help="Version of the Feed to download. (Default: %(default)s)",
         )
         parser.add_argument(
+            "--destination-prefix",
+            type=Path,
+            help="Prefix for the destination directories. (Default: %(default)s)",
+        )
+        parser.add_argument(
             "--gvmd-data-destination",
             type=Path,
             help="Destination of the downloaded gvmd data. "
@@ -343,6 +348,9 @@ class CliParser:
 
         if known_args.feed_version:
             config["feed-version"] = known_args.feed_version
+
+        if known_args.destination_prefix:
+            config["destination-prefix"] = known_args.destination_prefix
 
         if self.parser.prog == "greenbone-nvt-sync":
             config["type"] = "nvt"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,29 +13,13 @@ from unittest.mock import MagicMock, patch
 from pontos.testing import temp_file
 
 from greenbone.feed.sync.config import (
-    DEFAULT_CERT_DATA_PATH,
-    DEFAULT_CERT_DATA_URL_PATH,
     DEFAULT_DESTINATION_PREFIX,
     DEFAULT_ENTERPRISE_KEY_PATH,
+    DEFAULT_FEED_VERSION,
     DEFAULT_GROUP,
-    DEFAULT_GVMD_DATA_PATH,
-    DEFAULT_GVMD_DATA_URL_PATH,
     DEFAULT_GVMD_LOCK_FILE_PATH,
-    DEFAULT_NASL_PATH,
-    DEFAULT_NASL_URL_PATH,
-    DEFAULT_NOTUS_PATH,
-    DEFAULT_NOTUS_URL_PATH,
     DEFAULT_OPENVAS_LOCK_FILE_PATH,
-    DEFAULT_PORT_LISTS_PATH,
-    DEFAULT_PORT_LISTS_URL_PATH,
-    DEFAULT_REPORT_FORMATS_PATH,
-    DEFAULT_REPORT_FORMATS_URL_PATH,
-    DEFAULT_SCAN_CONFIGS_PATH,
-    DEFAULT_SCAN_CONFIGS_URL_PATH,
-    DEFAULT_SCAP_DATA_PATH,
-    DEFAULT_SCAP_DATA_URL_PATH,
     DEFAULT_USER,
-    DEFAULT_VERSION,
     Config,
     EnterpriseSettings,
 )
@@ -51,72 +35,93 @@ class ConfigTestCase(unittest.TestCase):
     def test_defaults(self):
         values = Config.load()
 
-        self.assertEqual(len(values), 30)
+        self.assertEqual(len(values), 31)
         self.assertEqual(
             values["destination-prefix"], Path(DEFAULT_DESTINATION_PREFIX)
         )
         self.assertEqual(
             values["gvmd-data-destination"],
-            Path(DEFAULT_DESTINATION_PREFIX) / DEFAULT_GVMD_DATA_PATH,
+            Path(DEFAULT_DESTINATION_PREFIX)
+            / "gvm"
+            / "data-objects"
+            / "gvmd"
+            / DEFAULT_FEED_VERSION,
         )
         self.assertEqual(
             values["gvmd-data-url"],
-            f"{DEFAULT_RSYNC_URL}{DEFAULT_GVMD_DATA_URL_PATH}",
+            f"{DEFAULT_RSYNC_URL}/data-feed/{DEFAULT_FEED_VERSION}/",
         )
         self.assertEqual(values["feed-url"], DEFAULT_RSYNC_URL)
         self.assertEqual(
             values["notus-destination"],
-            Path(DEFAULT_DESTINATION_PREFIX) / DEFAULT_NOTUS_PATH,
+            Path(DEFAULT_DESTINATION_PREFIX) / "notus",
         )
         self.assertEqual(
-            values["notus-url"], f"{DEFAULT_RSYNC_URL}{DEFAULT_NOTUS_URL_PATH}"
+            values["notus-url"],
+            f"{DEFAULT_RSYNC_URL}/vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/notus/",
         )
         self.assertEqual(
             values["nasl-destination"],
-            Path(DEFAULT_DESTINATION_PREFIX) / DEFAULT_NASL_PATH,
+            Path(DEFAULT_DESTINATION_PREFIX) / "openvas" / "plugins",
         )
         self.assertEqual(
-            values["nasl-url"], f"{DEFAULT_RSYNC_URL}{DEFAULT_NASL_URL_PATH}"
+            values["nasl-url"],
+            f"{DEFAULT_RSYNC_URL}/vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/nasl/",
         )
         self.assertEqual(
             values["scap-data-destination"],
-            Path(DEFAULT_DESTINATION_PREFIX) / DEFAULT_SCAP_DATA_PATH,
+            Path(DEFAULT_DESTINATION_PREFIX) / "gvm" / "scap-data",
         )
         self.assertEqual(
             values["scap-data-url"],
-            f"{DEFAULT_RSYNC_URL}{DEFAULT_SCAP_DATA_URL_PATH}",
+            f"{DEFAULT_RSYNC_URL}/vulnerability-feed/{DEFAULT_FEED_VERSION}/scap-data/",
         )
         self.assertEqual(
             values["cert-data-destination"],
-            Path(DEFAULT_DESTINATION_PREFIX) / DEFAULT_CERT_DATA_PATH,
+            Path(DEFAULT_DESTINATION_PREFIX) / "gvm" / "cert-data",
         )
         self.assertEqual(
             values["cert-data-url"],
-            f"{DEFAULT_RSYNC_URL}{DEFAULT_CERT_DATA_URL_PATH}",
+            f"{DEFAULT_RSYNC_URL}/vulnerability-feed/{DEFAULT_FEED_VERSION}/cert-data/",
         )
         self.assertEqual(
             values["report-formats-destination"],
-            Path(DEFAULT_DESTINATION_PREFIX) / DEFAULT_REPORT_FORMATS_PATH,
+            Path(DEFAULT_DESTINATION_PREFIX)
+            / "gvm"
+            / "data-objects"
+            / "gvmd"
+            / DEFAULT_FEED_VERSION
+            / "report-formats",
         )
         self.assertEqual(
             values["report-formats-url"],
-            f"{DEFAULT_RSYNC_URL}{DEFAULT_REPORT_FORMATS_URL_PATH}",
+            f"{DEFAULT_RSYNC_URL}/data-feed/{DEFAULT_FEED_VERSION}/report-formats/",
         )
         self.assertEqual(
             values["scan-configs-destination"],
-            Path(DEFAULT_DESTINATION_PREFIX) / DEFAULT_SCAN_CONFIGS_PATH,
+            Path(DEFAULT_DESTINATION_PREFIX)
+            / "gvm"
+            / "data-objects"
+            / "gvmd"
+            / DEFAULT_FEED_VERSION
+            / "scan-configs",
         )
         self.assertEqual(
             values["scan-configs-url"],
-            f"{DEFAULT_RSYNC_URL}{DEFAULT_SCAN_CONFIGS_URL_PATH}",
+            f"{DEFAULT_RSYNC_URL}/data-feed/{DEFAULT_FEED_VERSION}/scan-configs/",
         )
         self.assertEqual(
             values["port-lists-destination"],
-            Path(DEFAULT_DESTINATION_PREFIX) / DEFAULT_PORT_LISTS_PATH,
+            Path(DEFAULT_DESTINATION_PREFIX)
+            / "gvm"
+            / "data-objects"
+            / "gvmd"
+            / DEFAULT_FEED_VERSION
+            / "port-lists",
         )
         self.assertEqual(
             values["port-lists-url"],
-            f"{DEFAULT_RSYNC_URL}{DEFAULT_PORT_LISTS_URL_PATH}",
+            f"{DEFAULT_RSYNC_URL}/data-feed/{DEFAULT_FEED_VERSION}/port-lists/",
         )
         self.assertEqual(
             values["gvmd-lock-file"],
@@ -141,6 +146,7 @@ class ConfigTestCase(unittest.TestCase):
             values["greenbone-enterprise-feed-key"],
             Path(DEFAULT_ENTERPRISE_KEY_PATH),
         )
+        self.assertEqual(values["feed-version"], DEFAULT_FEED_VERSION)
 
     def test_config_file(self):
         content = """[greenbone-feed-sync]
@@ -174,6 +180,7 @@ rsync-timeout = 120
 group = "foo"
 user = "bar"
 greenbone-enterprise-feed-key = "/srv/feed.key"
+feed-version = "1.2.3"
 """
         path_mock = MagicMock(spec=Path)
         path_mock.read_text.return_value = content
@@ -239,6 +246,7 @@ greenbone-enterprise-feed-key = "/srv/feed.key"
         self.assertEqual(
             values["greenbone-enterprise-feed-key"], Path("/srv/feed.key")
         )
+        self.assertEqual(values["feed-version"], "1.2.3")
 
     def test_destination_prefix(self):
         content = """[greenbone-feed-sync]
@@ -253,7 +261,7 @@ destination-prefix = "/opt/lib/"
         self.assertEqual(values["destination-prefix"], Path("/opt/lib"))
         self.assertEqual(
             values["gvmd-data-destination"],
-            Path(f"/opt/lib/gvm/data-objects/gvmd/{DEFAULT_VERSION}"),
+            Path(f"/opt/lib/gvm/data-objects/gvmd/{DEFAULT_FEED_VERSION}"),
         )
         self.assertEqual(values["notus-destination"], Path("/opt/lib/notus"))
         self.assertEqual(
@@ -268,19 +276,19 @@ destination-prefix = "/opt/lib/"
         self.assertEqual(
             values["report-formats-destination"],
             Path(
-                f"/opt/lib/gvm/data-objects/gvmd/{DEFAULT_VERSION}/report-formats"
+                f"/opt/lib/gvm/data-objects/gvmd/{DEFAULT_FEED_VERSION}/report-formats"
             ),
         )
         self.assertEqual(
             values["scan-configs-destination"],
             Path(
-                f"/opt/lib/gvm/data-objects/gvmd/{DEFAULT_VERSION}/scan-configs"
+                f"/opt/lib/gvm/data-objects/gvmd/{DEFAULT_FEED_VERSION}/scan-configs"
             ),
         )
         self.assertEqual(
             values["port-lists-destination"],
             Path(
-                f"/opt/lib/gvm/data-objects/gvmd/{DEFAULT_VERSION}/port-lists"
+                f"/opt/lib/gvm/data-objects/gvmd/{DEFAULT_FEED_VERSION}/port-lists"
             ),
         )
         self.assertEqual(
@@ -303,35 +311,35 @@ feed-url = "rsync://foo.bar"
         self.assertEqual(values["feed-url"], "rsync://foo.bar")
         self.assertEqual(
             values["gvmd-data-url"],
-            f"rsync://foo.bar/data-feed/{DEFAULT_VERSION}/",
+            f"rsync://foo.bar/data-feed/{DEFAULT_FEED_VERSION}/",
         )
         self.assertEqual(
             values["notus-url"],
-            f"rsync://foo.bar/vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/",
+            f"rsync://foo.bar/vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/notus/",
         )
         self.assertEqual(
             values["nasl-url"],
-            f"rsync://foo.bar/vulnerability-feed/{DEFAULT_VERSION}/vt-data/nasl/",
+            f"rsync://foo.bar/vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/nasl/",
         )
         self.assertEqual(
             values["scap-data-url"],
-            f"rsync://foo.bar/vulnerability-feed/{DEFAULT_VERSION}/scap-data/",
+            f"rsync://foo.bar/vulnerability-feed/{DEFAULT_FEED_VERSION}/scap-data/",
         )
         self.assertEqual(
             values["cert-data-url"],
-            f"rsync://foo.bar/vulnerability-feed/{DEFAULT_VERSION}/cert-data/",
+            f"rsync://foo.bar/vulnerability-feed/{DEFAULT_FEED_VERSION}/cert-data/",
         )
         self.assertEqual(
             values["report-formats-url"],
-            f"rsync://foo.bar/data-feed/{DEFAULT_VERSION}/report-formats/",
+            f"rsync://foo.bar/data-feed/{DEFAULT_FEED_VERSION}/report-formats/",
         )
         self.assertEqual(
             values["scan-configs-url"],
-            f"rsync://foo.bar/data-feed/{DEFAULT_VERSION}/scan-configs/",
+            f"rsync://foo.bar/data-feed/{DEFAULT_FEED_VERSION}/scan-configs/",
         )
         self.assertEqual(
             values["port-lists-url"],
-            f"rsync://foo.bar/data-feed/{DEFAULT_VERSION}/port-lists/",
+            f"rsync://foo.bar/data-feed/{DEFAULT_FEED_VERSION}/port-lists/",
         )
 
     @patch.dict(
@@ -367,6 +375,7 @@ feed-url = "rsync://foo.bar"
             "GREENBONE_FEED_SYNC_GROUP": "123",
             "GREENBONE_FEED_SYNC_USER": "321",
             "GREENBONE_FEED_SYNC_ENTERPRISE_FEED_KEY": "/tmp/some.key",
+            "GREENBONE_FEED_SYNC_FEED_VERSION": "1.2.3",
         },
     )
     def test_environment(self):
@@ -428,6 +437,7 @@ feed-url = "rsync://foo.bar"
         self.assertEqual(
             values["greenbone-enterprise-feed-key"], Path("/tmp/some.key")
         )
+        self.assertEqual(values["feed-version"], "1.2.3")
 
     @patch.dict(
         "os.environ",
@@ -460,6 +470,7 @@ feed-url = "rsync://foo.bar"
             "GREENBONE_FEED_SYNC_FAIL_FAST": "1",
             "GREENBONE_FEED_SYNC_RSYNC_TIMEOUT": "120",
             "GREENBONE_FEED_SYNC_ENTERPRISE_FEED_KEY": "/tmp/some.key",
+            "GREENBONE_FEED_SYNC_FEED_VERSION": "1.2.3",
         },
     )
     def test_environment_overrides_config_file(self):
@@ -492,6 +503,7 @@ verbose = 99
 fail-fast = false
 rsync-timeout = 360
 greenbone-enterprise-feed-key = "/srv/feed.key"
+feed-version = "2.3.4"
 """
         path_mock = MagicMock(spec=Path)
         path_mock.read_text.return_value = content
@@ -551,6 +563,102 @@ greenbone-enterprise-feed-key = "/srv/feed.key"
         self.assertEqual(values["rsync-timeout"], 120)
         self.assertEqual(
             values["greenbone-enterprise-feed-key"], Path("/tmp/some.key")
+        )
+        self.assertEqual(values["feed-version"], "1.2.3")
+
+    def test_feed_version(self):
+        feed_version = "1.2.3"
+        content = f"""[greenbone-feed-sync]
+feed-version = "{feed_version}"
+"""
+        path_mock = MagicMock(spec=Path)
+        path_mock.read_text.return_value = content
+
+        values = Config.load(path_mock)
+
+        self.assertEqual(
+            values["gvmd-data-destination"],
+            Path(DEFAULT_DESTINATION_PREFIX)
+            / "gvm"
+            / "data-objects"
+            / "gvmd"
+            / feed_version,
+        )
+        self.assertEqual(
+            values["gvmd-data-url"],
+            f"{DEFAULT_RSYNC_URL}/data-feed/{feed_version}/",
+        )
+        self.assertEqual(values["feed-url"], DEFAULT_RSYNC_URL)
+        self.assertEqual(
+            values["notus-destination"],
+            Path(DEFAULT_DESTINATION_PREFIX) / "notus",
+        )
+        self.assertEqual(
+            values["notus-url"],
+            f"{DEFAULT_RSYNC_URL}/vulnerability-feed/{feed_version}/vt-data/notus/",
+        )
+        self.assertEqual(
+            values["nasl-destination"],
+            Path(DEFAULT_DESTINATION_PREFIX) / "openvas" / "plugins",
+        )
+        self.assertEqual(
+            values["nasl-url"],
+            f"{DEFAULT_RSYNC_URL}/vulnerability-feed/{feed_version}/vt-data/nasl/",
+        )
+        self.assertEqual(
+            values["scap-data-destination"],
+            Path(DEFAULT_DESTINATION_PREFIX) / "gvm" / "scap-data",
+        )
+        self.assertEqual(
+            values["scap-data-url"],
+            f"{DEFAULT_RSYNC_URL}/vulnerability-feed/{feed_version}/scap-data/",
+        )
+        self.assertEqual(
+            values["cert-data-destination"],
+            Path(DEFAULT_DESTINATION_PREFIX) / "gvm" / "cert-data",
+        )
+        self.assertEqual(
+            values["cert-data-url"],
+            f"{DEFAULT_RSYNC_URL}/vulnerability-feed/{feed_version}/cert-data/",
+        )
+        self.assertEqual(
+            values["report-formats-destination"],
+            Path(DEFAULT_DESTINATION_PREFIX)
+            / "gvm"
+            / "data-objects"
+            / "gvmd"
+            / feed_version
+            / "report-formats",
+        )
+        self.assertEqual(
+            values["report-formats-url"],
+            f"{DEFAULT_RSYNC_URL}/data-feed/{feed_version}/report-formats/",
+        )
+        self.assertEqual(
+            values["scan-configs-destination"],
+            Path(DEFAULT_DESTINATION_PREFIX)
+            / "gvm"
+            / "data-objects"
+            / "gvmd"
+            / feed_version
+            / "scan-configs",
+        )
+        self.assertEqual(
+            values["scan-configs-url"],
+            f"{DEFAULT_RSYNC_URL}/data-feed/{feed_version}/scan-configs/",
+        )
+        self.assertEqual(
+            values["port-lists-destination"],
+            Path(DEFAULT_DESTINATION_PREFIX)
+            / "gvm"
+            / "data-objects"
+            / "gvmd"
+            / feed_version
+            / "port-lists",
+        )
+        self.assertEqual(
+            values["port-lists-url"],
+            f"{DEFAULT_RSYNC_URL}/data-feed/{feed_version}/port-lists/",
         )
 
     def test_invalid_toml(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, call, patch
 
 from pontos.testing import temp_directory
 
-from greenbone.feed.sync.config import DEFAULT_VERSION
+from greenbone.feed.sync.config import DEFAULT_FEED_VERSION
 from greenbone.feed.sync.errors import GreenboneFeedSyncError, RsyncError
 from greenbone.feed.sync.main import (
     Sync,
@@ -113,12 +113,12 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
             [
                 call(
                     url="rsync://feed.community.greenbone.net/community/"
-                    f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/",
+                    f"vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/notus/",
                     destination=temp_dir / "notus",
                 ),
                 call(
                     url="rsync://feed.community.greenbone.net/community/"
-                    f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/nasl/",
+                    f"vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/nasl/",
                     destination=temp_dir / "openvas/plugins",
                 ),
             ]
@@ -174,12 +174,12 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
                 [
                     call(
                         url="rsync://feed.community.greenbone.net/community/"
-                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/",
+                        f"vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/notus/",
                         destination=temp_dir / "notus",
                     ),
                     call(
                         url="rsync://feed.community.greenbone.net/community/"
-                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/nasl/",
+                        f"vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/nasl/",
                         destination=temp_dir / "openvas/plugins",
                     ),
                 ]
@@ -223,14 +223,14 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
                     call(
                         "Downloading Notus files from "
                         "rsync://feed.community.greenbone.net/community/"
-                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/ "
+                        f"vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/notus/ "
                         f"to {temp_dir}/notus"
                     ),
                     call(),
                     call(
                         "Downloading NASL files from "
                         "rsync://feed.community.greenbone.net/community/"
-                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/nasl/ "
+                        f"vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/nasl/ "
                         f"to {temp_dir}/openvas/plugins"
                     ),
                     call(),
@@ -245,12 +245,12 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
                 [
                     call(
                         url="rsync://feed.community.greenbone.net/community/"
-                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/",
+                        f"vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/notus/",
                         destination=temp_dir / "notus",
                     ),
                     call(
                         url="rsync://feed.community.greenbone.net/community/"
-                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/nasl/",
+                        f"vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/nasl/",
                         destination=temp_dir / "openvas/plugins",
                     ),
                 ]
@@ -288,12 +288,12 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
                 [
                     call(
                         url="rsync://feed.community.greenbone.net/community/"
-                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/",
+                        f"vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/notus/",
                         destination=temp_dir / "notus",
                     ),
                     call(
                         url="rsync://feed.community.greenbone.net/community/"
-                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/nasl/",
+                        f"vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/nasl/",
                         destination=temp_dir / "openvas/plugins",
                     ),
                 ]
@@ -348,7 +348,7 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
                 [
                     call(
                         url="rsync://feed.community.greenbone.net/community/"
-                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/",
+                        f"vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/notus/",
                         destination=temp_dir / "notus",
                     ),
                 ]
@@ -409,12 +409,12 @@ class MainFunctionTestCase(unittest.TestCase):
                 [
                     call(
                         url="rsync://feed.community.greenbone.net/community/"
-                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/",
+                        f"vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/notus/",
                         destination=temp_dir / "notus",
                     ),
                     call(
                         url="rsync://feed.community.greenbone.net/community/"
-                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/nasl/",
+                        f"vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/nasl/",
                         destination=temp_dir / "openvas/plugins",
                     ),
                 ]
@@ -474,7 +474,7 @@ class MainFunctionTestCase(unittest.TestCase):
                 [
                     call(
                         url="rsync://feed.community.greenbone.net/community/"
-                        f"vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/",
+                        f"vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/notus/",
                         destination=temp_dir / "notus",
                     ),
                 ]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -212,6 +212,7 @@ class CliParserTestCase(unittest.TestCase):
             args.greenbone_enterprise_feed_key,
             Path(DEFAULT_ENTERPRISE_KEY_PATH),
         )
+        self.assertEqual(args.feed_version, DEFAULT_FEED_VERSION)
 
     def test_help(self):
         parser = CliParser()
@@ -830,3 +831,45 @@ sed diam nonumy eirmod tempor
         args = parser.parse_arguments([])
 
         self.assertEqual(args.type, "cert")
+
+    def test_feed_version(self):
+        parser = CliParser()
+        feed_version = "1.2.3"
+        args = parser.parse_arguments(["--feed-version", feed_version])
+        self.assertTrue(args.feed_version, "1.2.3")
+
+        self.assertEqual(
+            args.feed_url, "rsync://feed.community.greenbone.net/community"
+        )
+        self.assertEqual(
+            args.gvmd_data_url,
+            f"rsync://feed.community.greenbone.net/community/data-feed/{feed_version}/",
+        )
+        self.assertEqual(
+            args.port_lists_url,
+            f"rsync://feed.community.greenbone.net/community/data-feed/{feed_version}/port-lists/",
+        )
+        self.assertEqual(
+            args.report_formats_url,
+            f"rsync://feed.community.greenbone.net/community/data-feed/{feed_version}/report-formats/",
+        )
+        self.assertEqual(
+            args.scan_configs_url,
+            f"rsync://feed.community.greenbone.net/community/data-feed/{feed_version}/scan-configs/",
+        )
+        self.assertEqual(
+            args.notus_url,
+            f"rsync://feed.community.greenbone.net/community/vulnerability-feed/{feed_version}/vt-data/notus/",
+        )
+        self.assertEqual(
+            args.nasl_url,
+            f"rsync://feed.community.greenbone.net/community/vulnerability-feed/{feed_version}/vt-data/nasl/",
+        )
+        self.assertEqual(
+            args.scap_data_url,
+            f"rsync://feed.community.greenbone.net/community/vulnerability-feed/{feed_version}/scap-data/",
+        )
+        self.assertEqual(
+            args.cert_data_url,
+            f"rsync://feed.community.greenbone.net/community/vulnerability-feed/{feed_version}/cert-data/",
+        )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -873,3 +873,72 @@ sed diam nonumy eirmod tempor
             args.cert_data_url,
             f"rsync://feed.community.greenbone.net/community/vulnerability-feed/{feed_version}/cert-data/",
         )
+
+    def test_destination_prefix(self):
+        parser = CliParser()
+        destination_prefix = "/tmp/foo/bar"
+        args = parser.parse_arguments(
+            ["--destination-prefix", destination_prefix]
+        )
+
+        self.assertEqual(args.type, "all")
+        self.assertEqual(args.destination_prefix, Path(destination_prefix))
+        self.assertEqual(
+            args.gvmd_data_destination,
+            Path(destination_prefix)
+            / "gvm"
+            / "data-objects"
+            / "gvmd"
+            / DEFAULT_FEED_VERSION,
+        )
+        self.assertEqual(
+            args.notus_destination,
+            Path(destination_prefix) / "notus",
+        )
+        self.assertEqual(
+            args.nasl_destination,
+            Path(destination_prefix) / "openvas" / "plugins",
+        )
+        self.assertEqual(
+            args.scap_data_destination,
+            Path(destination_prefix) / "gvm" / "scap-data",
+        )
+        self.assertEqual(
+            args.cert_data_destination,
+            Path(destination_prefix) / "gvm" / "cert-data",
+        )
+        self.assertEqual(
+            args.report_formats_destination,
+            Path(destination_prefix)
+            / "gvm"
+            / "data-objects"
+            / "gvmd"
+            / DEFAULT_FEED_VERSION
+            / "report-formats",
+        )
+        self.assertEqual(
+            args.scan_configs_destination,
+            Path(destination_prefix)
+            / "gvm"
+            / "data-objects"
+            / "gvmd"
+            / DEFAULT_FEED_VERSION
+            / "scan-configs",
+        )
+        self.assertEqual(
+            args.port_lists_destination,
+            Path(destination_prefix)
+            / "gvm"
+            / "data-objects"
+            / "gvmd"
+            / DEFAULT_FEED_VERSION
+            / "port-lists",
+        )
+        self.assertEqual(
+            args.gvmd_lock_file,
+            Path(destination_prefix) / DEFAULT_GVMD_LOCK_FILE_PATH,
+        )
+        self.assertEqual(
+            args.openvas_lock_file,
+            Path(destination_prefix) / DEFAULT_OPENVAS_LOCK_FILE_PATH,
+        )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -15,29 +15,13 @@ from unittest.mock import MagicMock, patch
 from pontos.testing import temp_file
 
 from greenbone.feed.sync.config import (
-    DEFAULT_CERT_DATA_PATH,
-    DEFAULT_CERT_DATA_URL_PATH,
     DEFAULT_CONFIG_FILE,
     DEFAULT_DESTINATION_PREFIX,
     DEFAULT_ENTERPRISE_KEY_PATH,
-    DEFAULT_GVMD_DATA_PATH,
-    DEFAULT_GVMD_DATA_URL_PATH,
+    DEFAULT_FEED_VERSION,
     DEFAULT_GVMD_LOCK_FILE_PATH,
-    DEFAULT_NASL_PATH,
-    DEFAULT_NASL_URL_PATH,
-    DEFAULT_NOTUS_PATH,
-    DEFAULT_NOTUS_URL_PATH,
     DEFAULT_OPENVAS_LOCK_FILE_PATH,
-    DEFAULT_PORT_LISTS_PATH,
-    DEFAULT_PORT_LISTS_URL_PATH,
-    DEFAULT_REPORT_FORMATS_PATH,
-    DEFAULT_REPORT_FORMATS_URL_PATH,
-    DEFAULT_SCAN_CONFIGS_PATH,
-    DEFAULT_SCAN_CONFIGS_URL_PATH,
-    DEFAULT_SCAP_DATA_PATH,
-    DEFAULT_SCAP_DATA_URL_PATH,
     DEFAULT_USER_CONFIG_FILE,
-    DEFAULT_VERSION,
 )
 from greenbone.feed.sync.errors import ConfigFileError
 from greenbone.feed.sync.helper import DEFAULT_FLOCK_WAIT_INTERVAL
@@ -126,65 +110,86 @@ class CliParserTestCase(unittest.TestCase):
         self.assertEqual(args.feed_url, DEFAULT_RSYNC_URL)
         self.assertEqual(
             args.gvmd_data_destination,
-            Path(DEFAULT_DESTINATION_PREFIX) / DEFAULT_GVMD_DATA_PATH,
+            Path(DEFAULT_DESTINATION_PREFIX)
+            / "gvm"
+            / "data-objects"
+            / "gvmd"
+            / DEFAULT_FEED_VERSION,
         )
         self.assertEqual(
             args.gvmd_data_url,
-            f"{DEFAULT_RSYNC_URL}{DEFAULT_GVMD_DATA_URL_PATH}",
+            f"{DEFAULT_RSYNC_URL}/data-feed/{DEFAULT_FEED_VERSION}/",
         )
         self.assertEqual(
             args.notus_destination,
-            Path(DEFAULT_DESTINATION_PREFIX) / DEFAULT_NOTUS_PATH,
+            Path(DEFAULT_DESTINATION_PREFIX) / "notus",
         )
         self.assertEqual(
-            args.notus_url, f"{DEFAULT_RSYNC_URL}{DEFAULT_NOTUS_URL_PATH}"
+            args.notus_url,
+            f"{DEFAULT_RSYNC_URL}/vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/notus/",
         )
         self.assertEqual(
             args.nasl_destination,
-            Path(DEFAULT_DESTINATION_PREFIX) / DEFAULT_NASL_PATH,
+            Path(DEFAULT_DESTINATION_PREFIX) / "openvas" / "plugins",
         )
         self.assertEqual(
-            args.nasl_url, f"{DEFAULT_RSYNC_URL}{DEFAULT_NASL_URL_PATH}"
+            args.nasl_url,
+            f"{DEFAULT_RSYNC_URL}/vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/nasl/",
         )
         self.assertEqual(
             args.scap_data_destination,
-            Path(DEFAULT_DESTINATION_PREFIX) / DEFAULT_SCAP_DATA_PATH,
+            Path(DEFAULT_DESTINATION_PREFIX) / "gvm" / "scap-data",
         )
         self.assertEqual(
             args.scap_data_url,
-            f"{DEFAULT_RSYNC_URL}{DEFAULT_SCAP_DATA_URL_PATH}",
+            f"{DEFAULT_RSYNC_URL}/vulnerability-feed/{DEFAULT_FEED_VERSION}/scap-data/",
         )
         self.assertEqual(
             args.cert_data_destination,
-            Path(DEFAULT_DESTINATION_PREFIX) / DEFAULT_CERT_DATA_PATH,
+            Path(DEFAULT_DESTINATION_PREFIX) / "gvm" / "cert-data",
         )
         self.assertEqual(
             args.cert_data_url,
-            f"{DEFAULT_RSYNC_URL}{DEFAULT_CERT_DATA_URL_PATH}",
+            f"{DEFAULT_RSYNC_URL}/vulnerability-feed/{DEFAULT_FEED_VERSION}/cert-data/",
         )
         self.assertEqual(
             args.report_formats_destination,
-            Path(DEFAULT_DESTINATION_PREFIX) / DEFAULT_REPORT_FORMATS_PATH,
+            Path(DEFAULT_DESTINATION_PREFIX)
+            / "gvm"
+            / "data-objects"
+            / "gvmd"
+            / DEFAULT_FEED_VERSION
+            / "report-formats",
         )
         self.assertEqual(
             args.report_formats_url,
-            f"{DEFAULT_RSYNC_URL}{DEFAULT_REPORT_FORMATS_URL_PATH}",
+            f"{DEFAULT_RSYNC_URL}/data-feed/{DEFAULT_FEED_VERSION}/report-formats/",
         )
         self.assertEqual(
             args.scan_configs_destination,
-            Path(DEFAULT_DESTINATION_PREFIX) / DEFAULT_SCAN_CONFIGS_PATH,
+            Path(DEFAULT_DESTINATION_PREFIX)
+            / "gvm"
+            / "data-objects"
+            / "gvmd"
+            / DEFAULT_FEED_VERSION
+            / "scan-configs",
         )
         self.assertEqual(
             args.scan_configs_url,
-            f"{DEFAULT_RSYNC_URL}{DEFAULT_SCAN_CONFIGS_URL_PATH}",
+            f"{DEFAULT_RSYNC_URL}/data-feed/{DEFAULT_FEED_VERSION}/scan-configs/",
         )
         self.assertEqual(
             args.port_lists_destination,
-            Path(DEFAULT_DESTINATION_PREFIX) / DEFAULT_PORT_LISTS_PATH,
+            Path(DEFAULT_DESTINATION_PREFIX)
+            / "gvm"
+            / "data-objects"
+            / "gvmd"
+            / DEFAULT_FEED_VERSION
+            / "port-lists",
         )
         self.assertEqual(
             args.port_lists_url,
-            f"{DEFAULT_RSYNC_URL}{DEFAULT_PORT_LISTS_URL_PATH}",
+            f"{DEFAULT_RSYNC_URL}/data-feed/{DEFAULT_FEED_VERSION}/port-lists/",
         )
         self.assertEqual(
             args.gvmd_lock_file,
@@ -732,35 +737,35 @@ sed diam nonumy eirmod tempor
             )
             self.assertEqual(
                 args.gvmd_data_url,
-                f"ssh://a_user@some.feed.server/enterprise/data-feed/{DEFAULT_VERSION}/",
+                f"ssh://a_user@some.feed.server/enterprise/data-feed/{DEFAULT_FEED_VERSION}/",
             )
             self.assertEqual(
                 args.port_lists_url,
-                f"ssh://a_user@some.feed.server/enterprise/data-feed/{DEFAULT_VERSION}/port-lists/",
+                f"ssh://a_user@some.feed.server/enterprise/data-feed/{DEFAULT_FEED_VERSION}/port-lists/",
             )
             self.assertEqual(
                 args.report_formats_url,
-                f"ssh://a_user@some.feed.server/enterprise/data-feed/{DEFAULT_VERSION}/report-formats/",
+                f"ssh://a_user@some.feed.server/enterprise/data-feed/{DEFAULT_FEED_VERSION}/report-formats/",
             )
             self.assertEqual(
                 args.scan_configs_url,
-                f"ssh://a_user@some.feed.server/enterprise/data-feed/{DEFAULT_VERSION}/scan-configs/",
+                f"ssh://a_user@some.feed.server/enterprise/data-feed/{DEFAULT_FEED_VERSION}/scan-configs/",
             )
             self.assertEqual(
                 args.notus_url,
-                f"ssh://a_user@some.feed.server/enterprise/vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/",
+                f"ssh://a_user@some.feed.server/enterprise/vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/notus/",
             )
             self.assertEqual(
                 args.nasl_url,
-                f"ssh://a_user@some.feed.server/enterprise/vulnerability-feed/{DEFAULT_VERSION}/vt-data/nasl/",
+                f"ssh://a_user@some.feed.server/enterprise/vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/nasl/",
             )
             self.assertEqual(
                 args.scap_data_url,
-                f"ssh://a_user@some.feed.server/enterprise/vulnerability-feed/{DEFAULT_VERSION}/scap-data/",
+                f"ssh://a_user@some.feed.server/enterprise/vulnerability-feed/{DEFAULT_FEED_VERSION}/scap-data/",
             )
             self.assertEqual(
                 args.cert_data_url,
-                f"ssh://a_user@some.feed.server/enterprise/vulnerability-feed/{DEFAULT_VERSION}/cert-data/",
+                f"ssh://a_user@some.feed.server/enterprise/vulnerability-feed/{DEFAULT_FEED_VERSION}/cert-data/",
             )
 
     def test_ignore_non_existing_enterprise_feed_key(self):
@@ -774,35 +779,35 @@ sed diam nonumy eirmod tempor
         )
         self.assertEqual(
             args.gvmd_data_url,
-            f"rsync://feed.community.greenbone.net/community/data-feed/{DEFAULT_VERSION}/",
+            f"rsync://feed.community.greenbone.net/community/data-feed/{DEFAULT_FEED_VERSION}/",
         )
         self.assertEqual(
             args.port_lists_url,
-            f"rsync://feed.community.greenbone.net/community/data-feed/{DEFAULT_VERSION}/port-lists/",
+            f"rsync://feed.community.greenbone.net/community/data-feed/{DEFAULT_FEED_VERSION}/port-lists/",
         )
         self.assertEqual(
             args.report_formats_url,
-            f"rsync://feed.community.greenbone.net/community/data-feed/{DEFAULT_VERSION}/report-formats/",
+            f"rsync://feed.community.greenbone.net/community/data-feed/{DEFAULT_FEED_VERSION}/report-formats/",
         )
         self.assertEqual(
             args.scan_configs_url,
-            f"rsync://feed.community.greenbone.net/community/data-feed/{DEFAULT_VERSION}/scan-configs/",
+            f"rsync://feed.community.greenbone.net/community/data-feed/{DEFAULT_FEED_VERSION}/scan-configs/",
         )
         self.assertEqual(
             args.notus_url,
-            f"rsync://feed.community.greenbone.net/community/vulnerability-feed/{DEFAULT_VERSION}/vt-data/notus/",
+            f"rsync://feed.community.greenbone.net/community/vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/notus/",
         )
         self.assertEqual(
             args.nasl_url,
-            f"rsync://feed.community.greenbone.net/community/vulnerability-feed/{DEFAULT_VERSION}/vt-data/nasl/",
+            f"rsync://feed.community.greenbone.net/community/vulnerability-feed/{DEFAULT_FEED_VERSION}/vt-data/nasl/",
         )
         self.assertEqual(
             args.scap_data_url,
-            f"rsync://feed.community.greenbone.net/community/vulnerability-feed/{DEFAULT_VERSION}/scap-data/",
+            f"rsync://feed.community.greenbone.net/community/vulnerability-feed/{DEFAULT_FEED_VERSION}/scap-data/",
         )
         self.assertEqual(
             args.cert_data_url,
-            f"rsync://feed.community.greenbone.net/community/vulnerability-feed/{DEFAULT_VERSION}/cert-data/",
+            f"rsync://feed.community.greenbone.net/community/vulnerability-feed/{DEFAULT_FEED_VERSION}/cert-data/",
         )
 
     @patch.object(sys, "argv", ["greenbone-nvt-sync"])


### PR DESCRIPTION
## What

Adjust greenbone-feed-sync to allow downloading different feeds and download our latest feed (24.10) by default. Currently it is very difficult to detect which version of the feed a user needs. Therefore greenbone-feed-sync assumes the latest feed version is desired. If not the to be downloaded feed version can be adjusted easily via the config file, environment variable or CLI argument. Please take a look at the README for further details.

## Why

Download the latest feed version expected by the stable gvmd version.

## References

https://jira.greenbone.net/browse/GEA-890

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


