### PR TITLE
Drop the feed version from gvmd data directories by default

### DIFF
--- a/greenbone/feed/sync/config.py
+++ b/greenbone/feed/sync/config.py
@@ -5,7 +5,6 @@
 
 import os
 from dataclasses import dataclass
-from multiprocessing import Value
 from pathlib import Path
 from typing import (
     Any,

--- a/greenbone/feed/sync/errors.py
+++ b/greenbone/feed/sync/errors.py
@@ -25,7 +25,13 @@ class GreenboneFeedSyncError(Exception):
     """
 
 
-class ConfigFileError(GreenboneFeedSyncError):
+class ConfigError(GreenboneFeedSyncError):
+    """
+    Error while processing a config
+    """
+
+
+class ConfigFileError(ConfigError):
     """
     Error while processing a config file
     """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,11 +41,7 @@ class ConfigTestCase(unittest.TestCase):
         )
         self.assertEqual(
             values["gvmd-data-destination"],
-            Path(DEFAULT_DESTINATION_PREFIX)
-            / "gvm"
-            / "data-objects"
-            / "gvmd"
-            / DEFAULT_FEED_VERSION,
+            Path(DEFAULT_DESTINATION_PREFIX) / "gvm" / "data-objects" / "gvmd",
         )
         self.assertEqual(
             values["gvmd-data-url"],
@@ -90,7 +86,6 @@ class ConfigTestCase(unittest.TestCase):
             / "gvm"
             / "data-objects"
             / "gvmd"
-            / DEFAULT_FEED_VERSION
             / "report-formats",
         )
         self.assertEqual(
@@ -103,7 +98,6 @@ class ConfigTestCase(unittest.TestCase):
             / "gvm"
             / "data-objects"
             / "gvmd"
-            / DEFAULT_FEED_VERSION
             / "scan-configs",
         )
         self.assertEqual(
@@ -116,7 +110,6 @@ class ConfigTestCase(unittest.TestCase):
             / "gvm"
             / "data-objects"
             / "gvmd"
-            / DEFAULT_FEED_VERSION
             / "port-lists",
         )
         self.assertEqual(
@@ -261,7 +254,7 @@ destination-prefix = "/opt/lib/"
         self.assertEqual(values["destination-prefix"], Path("/opt/lib"))
         self.assertEqual(
             values["gvmd-data-destination"],
-            Path(f"/opt/lib/gvm/data-objects/gvmd/{DEFAULT_FEED_VERSION}"),
+            Path("/opt/lib/gvm/data-objects/gvmd/"),
         )
         self.assertEqual(values["notus-destination"], Path("/opt/lib/notus"))
         self.assertEqual(
@@ -275,21 +268,15 @@ destination-prefix = "/opt/lib/"
         )
         self.assertEqual(
             values["report-formats-destination"],
-            Path(
-                f"/opt/lib/gvm/data-objects/gvmd/{DEFAULT_FEED_VERSION}/report-formats"
-            ),
+            Path("/opt/lib/gvm/data-objects/gvmd/report-formats"),
         )
         self.assertEqual(
             values["scan-configs-destination"],
-            Path(
-                f"/opt/lib/gvm/data-objects/gvmd/{DEFAULT_FEED_VERSION}/scan-configs"
-            ),
+            Path("/opt/lib/gvm/data-objects/gvmd/scan-configs"),
         )
         self.assertEqual(
             values["port-lists-destination"],
-            Path(
-                f"/opt/lib/gvm/data-objects/gvmd/{DEFAULT_FEED_VERSION}/port-lists"
-            ),
+            Path("/opt/lib/gvm/data-objects/gvmd/port-lists"),
         )
         self.assertEqual(
             values["openvas-lock-file"],

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -110,11 +110,7 @@ class CliParserTestCase(unittest.TestCase):
         self.assertEqual(args.feed_url, DEFAULT_RSYNC_URL)
         self.assertEqual(
             args.gvmd_data_destination,
-            Path(DEFAULT_DESTINATION_PREFIX)
-            / "gvm"
-            / "data-objects"
-            / "gvmd"
-            / DEFAULT_FEED_VERSION,
+            Path(DEFAULT_DESTINATION_PREFIX) / "gvm" / "data-objects" / "gvmd",
         )
         self.assertEqual(
             args.gvmd_data_url,
@@ -158,7 +154,6 @@ class CliParserTestCase(unittest.TestCase):
             / "gvm"
             / "data-objects"
             / "gvmd"
-            / DEFAULT_FEED_VERSION
             / "report-formats",
         )
         self.assertEqual(
@@ -171,7 +166,6 @@ class CliParserTestCase(unittest.TestCase):
             / "gvm"
             / "data-objects"
             / "gvmd"
-            / DEFAULT_FEED_VERSION
             / "scan-configs",
         )
         self.assertEqual(
@@ -184,7 +178,6 @@ class CliParserTestCase(unittest.TestCase):
             / "gvm"
             / "data-objects"
             / "gvmd"
-            / DEFAULT_FEED_VERSION
             / "port-lists",
         )
         self.assertEqual(
@@ -885,11 +878,7 @@ sed diam nonumy eirmod tempor
         self.assertEqual(args.destination_prefix, Path(destination_prefix))
         self.assertEqual(
             args.gvmd_data_destination,
-            Path(destination_prefix)
-            / "gvm"
-            / "data-objects"
-            / "gvmd"
-            / DEFAULT_FEED_VERSION,
+            Path(destination_prefix) / "gvm" / "data-objects" / "gvmd",
         )
         self.assertEqual(
             args.notus_destination,
@@ -913,7 +902,6 @@ sed diam nonumy eirmod tempor
             / "gvm"
             / "data-objects"
             / "gvmd"
-            / DEFAULT_FEED_VERSION
             / "report-formats",
         )
         self.assertEqual(
@@ -922,7 +910,6 @@ sed diam nonumy eirmod tempor
             / "gvm"
             / "data-objects"
             / "gvmd"
-            / DEFAULT_FEED_VERSION
             / "scan-configs",
         )
         self.assertEqual(
@@ -931,7 +918,6 @@ sed diam nonumy eirmod tempor
             / "gvm"
             / "data-objects"
             / "gvmd"
-            / DEFAULT_FEED_VERSION
             / "port-lists",
         )
         self.assertEqual(


### PR DESCRIPTION

## What

Drop the feed version from gvmd data directories by default

## Why

This change requires gvmd 25.0.0 and makes greenbone-feed-sync compatible with the 24.10 feed finally. The 24.10 feed is used by default with the current major release of greenbone-feed-sync.

Older feed versions for gvmd < 24.1.0 can be synced by setting the feed version. For example via the CLI argument `--feed-version 22.04`.

gvmd versions between 24.1.0 and 25.0.0 require to download the 24.10 feed into a 22.04 directory and are therefore considered broken.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


