### PR TITLE
CI-Workflow: add pull request write permission

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -27,3 +27,5 @@ jobs:
       ref-name: ${{ inputs.ref-name }}
       service: greenbone-feed-sync
     secrets: inherit
+    permissions:
+        pull-requests: write


### PR DESCRIPTION
In order to fix workflow issue / DEVOPS-1534

## What

Added permission pull-requests: write

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

Because the push job fails due to missing permissions for the workflow and the scout-command: cves that need to write a comment into the PR 

<!-- Describe why are these changes necessary? -->

## References

DEVOPS-1534

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ -] Tests 


