### PR TITLE
Use hatchling as build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [project]
 name = "greenbone-feed-sync"
 version = "25.2.1.dev1"
@@ -31,16 +35,11 @@ greenbone-certdata-sync = "greenbone.feed.sync.main:main"
 
 [tool.uv]
 
-[tool.uv.build-backend]
-module-name = ["greenbone", "tests"]
-module-root = ""
-namespace = true
-source-include = ["uv.lock"]
-wheel-exclude = ["tests"]
+[tool.hatch.build.targets.sdist]
+include = ["greenbone", "tests", "uv.lock"]
 
-[build-system]
-requires = ["uv_build>=0.11.6,<0.12.0"]
-build-backend = "uv_build"
+[tool.hatch.build.targets.wheel]
+packages = ["greenbone"]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION


## What

Use hatchling as build backend
## Why

Currently `uv_build` is not available as a Debian package. Therefore packaging greenbone-feed-sync for Debian is not possible with using `uv_build`. Instead change the build backend to hatchling which is available.

