### PR TITLE
feat: add optional --no-permission-change to skip rsync permission preservation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ and types.
   - [no-wait](#no-wait)
   - [wait-interval](#wait-interval)
   - [rsync-timeout](#rsync-timeout)
+  - [no-perms](#no-perms)
   - [group](#group)
   - [user](#user)
   - [greenbone-enterprise-feed-key](#greenbone-enterprise-feed-key)
@@ -523,6 +524,16 @@ is only required for experts and testing purposes.
 | Environment Variable | `GREENBONE_FEED_SYNC_RSYNC_TIMEOUT`                                                                                                                                                    |
 | Default Value        |                                                                                                                                                                                        |
 | Description          | Maximum I/O timeout in seconds used for rsync. If no data is transferred for the specified time then rsync will exit. By default no timeout is set and the rsync default will be used. |
+
+### no-perms
+
+| Name                 | Value                                                                                                                                                                                          |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CLI Argument         | `--no-perms`                                                                                                                                                                                    |
+| Config Variable      | no-perms                                                                                                                                                                                        |
+| Environment Variable | `GREENBONE_FEED_SYNC_NO_PERMS`                                                                                                                                                                  |
+| Default Value        | false                                                                                                                                                                                          |
+| Description          | Do not transfer permissions of the synced files and directories. By default rsync sets explicit permissions (`--perms --chmod=...`) on the destination. Enable this to pass `--no-perms` to rsync, for example when syncing to storage that denies changing permissions (such as object storage gateways). |
 
 ### group
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ and types.
   - [no-wait](#no-wait)
   - [wait-interval](#wait-interval)
   - [rsync-timeout](#rsync-timeout)
-  - [no-perms](#no-perms)
+  - [no-permission-change](#no-permission-change)
   - [group](#group)
   - [user](#user)
   - [greenbone-enterprise-feed-key](#greenbone-enterprise-feed-key)
@@ -525,15 +525,15 @@ is only required for experts and testing purposes.
 | Default Value        |                                                                                                                                                                                        |
 | Description          | Maximum I/O timeout in seconds used for rsync. If no data is transferred for the specified time then rsync will exit. By default no timeout is set and the rsync default will be used. |
 
-### no-perms
+### no-permission-change
 
 | Name                 | Value                                                                                                                                                                                          |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CLI Argument         | `--no-perms`                                                                                                                                                                                    |
-| Config Variable      | no-perms                                                                                                                                                                                        |
-| Environment Variable | `GREENBONE_FEED_SYNC_NO_PERMS`                                                                                                                                                                  |
+| CLI Argument         | `--no-permission-change`                                                                                                                                                                        |
+| Config Variable      | no-permission-change                                                                                                                                                                           |
+| Environment Variable | `GREENBONE_FEED_SYNC_NO_PERMISSION_CHANGE`                                                                                                                                                      |
 | Default Value        | false                                                                                                                                                                                          |
-| Description          | Do not transfer permissions of the synced files and directories. By default rsync sets explicit permissions (`--perms --chmod=...`) on the destination. Enable this to pass `--no-perms` to rsync, for example when syncing to storage that denies changing permissions (such as object storage gateways). |
+| Description          | Do not preserve permissions and skip normalizing the feed tree via rsync's `--perms` and `--chmod` options. By default permissions are preserved. Enable this to pass `--no-perms` to rsync, for storage that allows writing files but rejects changing their modes, for example some bind mounts, network filesystems or container volumes where rsync would otherwise fail with a permission error. |
 
 ### group
 

--- a/greenbone/feed/sync/config.py
+++ b/greenbone/feed/sync/config.py
@@ -159,6 +159,7 @@ _SETTINGS = (
         int,
     ),
     Setting("no-wait", "GREENBONE_FEED_SYNC_NO_WAIT", False, bool),
+    Setting("no-perms", "GREENBONE_FEED_SYNC_NO_PERMS", False, bool),
     Setting(
         "compression-level",
         "GREENBONE_FEED_SYNC_COMPRESSION_LEVEL",

--- a/greenbone/feed/sync/config.py
+++ b/greenbone/feed/sync/config.py
@@ -159,7 +159,12 @@ _SETTINGS = (
         int,
     ),
     Setting("no-wait", "GREENBONE_FEED_SYNC_NO_WAIT", False, bool),
-    Setting("no-perms", "GREENBONE_FEED_SYNC_NO_PERMS", False, bool),
+    Setting(
+        "no-permission-change",
+        "GREENBONE_FEED_SYNC_NO_PERMISSION_CHANGE",
+        False,
+        bool,
+    ),
     Setting(
         "compression-level",
         "GREENBONE_FEED_SYNC_COMPRESSION_LEVEL",

--- a/greenbone/feed/sync/main.py
+++ b/greenbone/feed/sync/main.py
@@ -105,6 +105,7 @@ async def feed_sync(console: Console, error_console: Console) -> int:
         verbose=verbose >= 3,
         compression_level=args.compression_level,
         ssh_key=args.greenbone_enterprise_feed_key,
+        perms=not args.no_perms,
     )
 
     openvas_syncs = filter_syncs(

--- a/greenbone/feed/sync/main.py
+++ b/greenbone/feed/sync/main.py
@@ -105,7 +105,7 @@ async def feed_sync(console: Console, error_console: Console) -> int:
         verbose=verbose >= 3,
         compression_level=args.compression_level,
         ssh_key=args.greenbone_enterprise_feed_key,
-        perms=not args.no_perms,
+        change_permissions=not args.no_permission_change,
     )
 
     openvas_syncs = filter_syncs(

--- a/greenbone/feed/sync/parser.py
+++ b/greenbone/feed/sync/parser.py
@@ -271,7 +271,7 @@ class CliParser:
         )
 
         parser.add_argument(
-            "--no-perms",
+            "--no-permission-change",
             action="store_true",
             help="Do not preserve permissions and skip normalizing the feed "
             "tree via rsync's --perms and --chmod options. By default "

--- a/greenbone/feed/sync/parser.py
+++ b/greenbone/feed/sync/parser.py
@@ -270,6 +270,17 @@ class CliParser:
             "default no timeout is set and the rsync default will be used.",
         )
 
+        parser.add_argument(
+            "--no-perms",
+            action="store_true",
+            help="Do not preserve permissions and skip normalizing the feed "
+            "tree via rsync's --perms and --chmod options. By default "
+            "permissions are preserved. Use this for storage that allows "
+            "writing files but rejects changing their modes, for example some "
+            "bind mounts, network filesystems or container volumes where rsync "
+            "would otherwise fail with a permission error.",
+        )
+
         permissions_group = parser.add_argument_group()
         permissions_group.add_argument(
             "--user",

--- a/greenbone/feed/sync/rsync.py
+++ b/greenbone/feed/sync/rsync.py
@@ -54,7 +54,7 @@ class Rsync:
             used of not set explicitly. 0 for no timeout.
         ssh_key: SSH key for using ssh as rsync transport protocol.
         exclude: An iterable of directories to exclude from the sync.
-        perms: Preserve permissions and normalize the feed tree via
+        change_permissions: Set and normalize permissions of the feed tree via
             ``--perms`` and ``--chmod``. Enabled by default. Set to ``False``
             to pass ``--no-perms`` instead, for storage that allows writing
             files but rejects changing their modes (for example some bind
@@ -71,7 +71,7 @@ class Rsync:
         timeout: int | None = DEFAULT_RSYNC_TIMEOUT,
         ssh_key: PathLike | None = None,
         exclude: Iterable[PathLike] | None = None,
-        perms: bool = True,
+        change_permissions: bool = True,
     ) -> None:
         self.verbose = verbose
         self.private_subdir = private_subdir
@@ -79,7 +79,7 @@ class Rsync:
         self.timeout = timeout
         self.ssh_key = ssh_key
         self.exclude = exclude
-        self.perms = perms
+        self.change_permissions = change_permissions
 
     async def sync(self, url: str, destination: PathLike) -> None:
         """
@@ -138,7 +138,7 @@ class Rsync:
                 "--perms",
                 "--chmod=Fugo+r,Fug+w,Dugo-s,Dugo+rx,Dug+w",
             ]
-            if self.perms
+            if self.change_permissions
             else [
                 "--no-perms",
             ]

--- a/greenbone/feed/sync/rsync.py
+++ b/greenbone/feed/sync/rsync.py
@@ -54,6 +54,11 @@ class Rsync:
             used of not set explicitly. 0 for no timeout.
         ssh_key: SSH key for using ssh as rsync transport protocol.
         exclude: An iterable of directories to exclude from the sync.
+        perms: Preserve permissions and normalize the feed tree via
+            ``--perms`` and ``--chmod``. Enabled by default. Set to ``False``
+            to pass ``--no-perms`` instead, for storage that allows writing
+            files but rejects changing their modes (for example some bind
+            mounts, network filesystems or container volumes).
 
     """
 
@@ -66,6 +71,7 @@ class Rsync:
         timeout: int | None = DEFAULT_RSYNC_TIMEOUT,
         ssh_key: PathLike | None = None,
         exclude: Iterable[PathLike] | None = None,
+        perms: bool = True,
     ) -> None:
         self.verbose = verbose
         self.private_subdir = private_subdir
@@ -73,6 +79,7 @@ class Rsync:
         self.timeout = timeout
         self.ssh_key = ssh_key
         self.exclude = exclude
+        self.perms = perms
 
     async def sync(self, url: str, destination: PathLike) -> None:
         """
@@ -126,10 +133,16 @@ class Rsync:
             "--delete",
         ]
 
-        rsync_chmod = [
-            "--perms",
-            "--chmod=Fugo+r,Fug+w,Dugo-s,Dugo+rx,Dug+w",
-        ]
+        rsync_chmod = (
+            [
+                "--perms",
+                "--chmod=Fugo+r,Fug+w,Dugo-s,Dugo+rx,Dug+w",
+            ]
+            if self.perms
+            else [
+                "--no-perms",
+            ]
+        )
 
         rsync_links = [
             "--copy-unsafe-links",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -125,7 +125,7 @@ class ConfigTestCase(unittest.TestCase):
         )
         self.assertEqual(values["wait-interval"], DEFAULT_FLOCK_WAIT_INTERVAL)
         self.assertFalse(values["no-wait"])
-        self.assertFalse(values["no-perms"])
+        self.assertFalse(values["no-permission-change"])
         self.assertEqual(
             values["compression-level"], DEFAULT_RSYNC_COMPRESSION_LEVEL
         )
@@ -165,7 +165,7 @@ openvas-lock-file = "/usr/lib/openvas.lock"
 gvmd-lock-file = "/usr/lib/gvmd.lock"
 wait-interval = 100
 no-wait = true
-no-perms = true
+no-permission-change = true
 compression-level = 1
 private-directory = "keep-this"
 verbose = 5
@@ -230,7 +230,7 @@ feed-release = "1.2.3"
         self.assertEqual(values["gvmd-lock-file"], Path("/usr/lib/gvmd.lock"))
         self.assertEqual(values["wait-interval"], 100)
         self.assertTrue(values["no-wait"])
-        self.assertTrue(values["no-perms"])
+        self.assertTrue(values["no-permission-change"])
         self.assertEqual(values["compression-level"], 1)
         self.assertEqual(values["private-directory"], Path("keep-this"))
         self.assertEqual(values["verbose"], 5)
@@ -361,7 +361,7 @@ feed-url = "rsync://foo.bar"
             "GREENBONE_FEED_SYNC_VERBOSE": "5",
             "GREENBONE_FEED_SYNC_FAIL_FAST": "1",
             "GREENBONE_FEED_SYNC_RSYNC_TIMEOUT": "120",
-            "GREENBONE_FEED_SYNC_NO_PERMS": "1",
+            "GREENBONE_FEED_SYNC_NO_PERMISSION_CHANGE": "1",
             "GREENBONE_FEED_SYNC_GROUP": "123",
             "GREENBONE_FEED_SYNC_USER": "321",
             "GREENBONE_FEED_SYNC_ENTERPRISE_FEED_KEY": "/tmp/some.key",
@@ -417,7 +417,7 @@ feed-url = "rsync://foo.bar"
         self.assertEqual(values["gvmd-lock-file"], Path("/usr/lib/gvmd.lock"))
         self.assertEqual(values["wait-interval"], 100)
         self.assertTrue(values["no-wait"])
-        self.assertTrue(values["no-perms"])
+        self.assertTrue(values["no-permission-change"])
         self.assertEqual(values["compression-level"], 1)
         self.assertEqual(values["private-directory"], Path("keep-this"))
         self.assertEqual(values["verbose"], 5)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,7 +34,7 @@ class ConfigTestCase(unittest.TestCase):
     def test_defaults(self):
         values = Config.load()
 
-        self.assertEqual(len(values), 31)
+        self.assertEqual(len(values), 32)
         self.assertEqual(
             values["destination-prefix"], Path(DEFAULT_DESTINATION_PREFIX)
         )
@@ -125,6 +125,7 @@ class ConfigTestCase(unittest.TestCase):
         )
         self.assertEqual(values["wait-interval"], DEFAULT_FLOCK_WAIT_INTERVAL)
         self.assertFalse(values["no-wait"])
+        self.assertFalse(values["no-perms"])
         self.assertEqual(
             values["compression-level"], DEFAULT_RSYNC_COMPRESSION_LEVEL
         )
@@ -164,6 +165,7 @@ openvas-lock-file = "/usr/lib/openvas.lock"
 gvmd-lock-file = "/usr/lib/gvmd.lock"
 wait-interval = 100
 no-wait = true
+no-perms = true
 compression-level = 1
 private-directory = "keep-this"
 verbose = 5
@@ -228,6 +230,7 @@ feed-release = "1.2.3"
         self.assertEqual(values["gvmd-lock-file"], Path("/usr/lib/gvmd.lock"))
         self.assertEqual(values["wait-interval"], 100)
         self.assertTrue(values["no-wait"])
+        self.assertTrue(values["no-perms"])
         self.assertEqual(values["compression-level"], 1)
         self.assertEqual(values["private-directory"], Path("keep-this"))
         self.assertEqual(values["verbose"], 5)
@@ -358,6 +361,7 @@ feed-url = "rsync://foo.bar"
             "GREENBONE_FEED_SYNC_VERBOSE": "5",
             "GREENBONE_FEED_SYNC_FAIL_FAST": "1",
             "GREENBONE_FEED_SYNC_RSYNC_TIMEOUT": "120",
+            "GREENBONE_FEED_SYNC_NO_PERMS": "1",
             "GREENBONE_FEED_SYNC_GROUP": "123",
             "GREENBONE_FEED_SYNC_USER": "321",
             "GREENBONE_FEED_SYNC_ENTERPRISE_FEED_KEY": "/tmp/some.key",
@@ -413,6 +417,7 @@ feed-url = "rsync://foo.bar"
         self.assertEqual(values["gvmd-lock-file"], Path("/usr/lib/gvmd.lock"))
         self.assertEqual(values["wait-interval"], 100)
         self.assertTrue(values["no-wait"])
+        self.assertTrue(values["no-perms"])
         self.assertEqual(values["compression-level"], 1)
         self.assertEqual(values["private-directory"], Path("keep-this"))
         self.assertEqual(values["verbose"], 5)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -96,6 +96,7 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
             verbose=False,
             compression_level=9,
             ssh_key=Path("/etc/gvm/greenbone-enterprise-feed-key"),
+            perms=True,
         )
         console.print.assert_has_calls(
             [
@@ -123,6 +124,38 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
                 ),
             ]
         )
+
+    @patch("greenbone.feed.sync.main.Rsync", autospec=True)
+    async def test_no_perms(self, rsync_mock: MagicMock):
+        console = MagicMock()
+
+        with (
+            temp_directory() as temp_dir,
+            patch.dict(
+                "os.environ",
+                {"GREENBONE_FEED_SYNC_DESTINATION_PREFIX": str(temp_dir)},
+            ),
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "greenbone-feed-sync",
+                    "--type",
+                    "nvt",
+                    "--no-perms",
+                ],
+            ),
+        ):
+            ret = await feed_sync(console=console, error_console=console)
+            self.assertEqual(ret, 0)
+
+            rsync_mock.assert_called_once_with(
+                private_subdir=None,
+                verbose=False,
+                compression_level=9,
+                ssh_key=Path("/etc/gvm/greenbone-enterprise-feed-key"),
+                perms=False,
+            )
 
     @patch("greenbone.feed.sync.main.Rsync", autospec=True)
     async def test_sync_nvts(self, rsync_mock: MagicMock):
@@ -153,6 +186,7 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
                 verbose=False,
                 compression_level=9,
                 ssh_key=Path("/etc/gvm/greenbone-enterprise-feed-key"),
+                perms=True,
             )
             console.print.assert_has_calls(
                 [
@@ -210,6 +244,7 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
                 verbose=True,
                 compression_level=9,
                 ssh_key=Path("/etc/gvm/greenbone-enterprise-feed-key"),
+                perms=True,
             )
             console.print.assert_has_calls(
                 [
@@ -281,6 +316,7 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
                 verbose=False,
                 compression_level=9,
                 ssh_key=Path("/etc/gvm/greenbone-enterprise-feed-key"),
+                perms=True,
             )
             console.print.assert_not_called()
 
@@ -327,6 +363,7 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
                 verbose=False,
                 compression_level=9,
                 ssh_key=Path("/etc/gvm/greenbone-enterprise-feed-key"),
+                perms=True,
             )
             console.print.assert_has_calls(
                 [
@@ -388,6 +425,7 @@ class MainFunctionTestCase(unittest.TestCase):
                 verbose=False,
                 compression_level=9,
                 ssh_key=Path("/etc/gvm/greenbone-enterprise-feed-key"),
+                perms=True,
             )
             console_mock_instance.print.assert_has_calls(
                 [
@@ -453,6 +491,7 @@ class MainFunctionTestCase(unittest.TestCase):
                 verbose=False,
                 compression_level=9,
                 ssh_key=Path("/etc/gvm/greenbone-enterprise-feed-key"),
+                perms=True,
             )
             console_mock_instance.print.assert_has_calls(
                 [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -96,7 +96,7 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
             verbose=False,
             compression_level=9,
             ssh_key=Path("/etc/gvm/greenbone-enterprise-feed-key"),
-            perms=True,
+            change_permissions=True,
         )
         console.print.assert_has_calls(
             [
@@ -126,7 +126,7 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
         )
 
     @patch("greenbone.feed.sync.main.Rsync", autospec=True)
-    async def test_no_perms(self, rsync_mock: MagicMock):
+    async def test_no_permission_change(self, rsync_mock: MagicMock):
         console = MagicMock()
 
         with (
@@ -142,7 +142,7 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
                     "greenbone-feed-sync",
                     "--type",
                     "nvt",
-                    "--no-perms",
+                    "--no-permission-change",
                 ],
             ),
         ):
@@ -154,7 +154,7 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
                 verbose=False,
                 compression_level=9,
                 ssh_key=Path("/etc/gvm/greenbone-enterprise-feed-key"),
-                perms=False,
+                change_permissions=False,
             )
 
     @patch("greenbone.feed.sync.main.Rsync", autospec=True)
@@ -186,7 +186,7 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
                 verbose=False,
                 compression_level=9,
                 ssh_key=Path("/etc/gvm/greenbone-enterprise-feed-key"),
-                perms=True,
+                change_permissions=True,
             )
             console.print.assert_has_calls(
                 [
@@ -244,7 +244,7 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
                 verbose=True,
                 compression_level=9,
                 ssh_key=Path("/etc/gvm/greenbone-enterprise-feed-key"),
-                perms=True,
+                change_permissions=True,
             )
             console.print.assert_has_calls(
                 [
@@ -316,7 +316,7 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
                 verbose=False,
                 compression_level=9,
                 ssh_key=Path("/etc/gvm/greenbone-enterprise-feed-key"),
-                perms=True,
+                change_permissions=True,
             )
             console.print.assert_not_called()
 
@@ -363,7 +363,7 @@ class FeedSyncTestCase(unittest.IsolatedAsyncioTestCase):
                 verbose=False,
                 compression_level=9,
                 ssh_key=Path("/etc/gvm/greenbone-enterprise-feed-key"),
-                perms=True,
+                change_permissions=True,
             )
             console.print.assert_has_calls(
                 [
@@ -425,7 +425,7 @@ class MainFunctionTestCase(unittest.TestCase):
                 verbose=False,
                 compression_level=9,
                 ssh_key=Path("/etc/gvm/greenbone-enterprise-feed-key"),
-                perms=True,
+                change_permissions=True,
             )
             console_mock_instance.print.assert_has_calls(
                 [
@@ -491,7 +491,7 @@ class MainFunctionTestCase(unittest.TestCase):
                 verbose=False,
                 compression_level=9,
                 ssh_key=Path("/etc/gvm/greenbone-enterprise-feed-key"),
-                perms=True,
+                change_permissions=True,
             )
             console_mock_instance.print.assert_has_calls(
                 [

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -194,6 +194,7 @@ class CliParserTestCase(unittest.TestCase):
         )
         self.assertEqual(args.wait_interval, DEFAULT_FLOCK_WAIT_INTERVAL)
         self.assertFalse(args.no_wait)
+        self.assertFalse(args.no_perms)
         self.assertEqual(
             args.compression_level, DEFAULT_RSYNC_COMPRESSION_LEVEL
         )
@@ -425,6 +426,11 @@ class CliParserTestCase(unittest.TestCase):
         parser = CliParser()
         args = parser.parse_arguments(["--no-wait"])
         self.assertTrue(args.no_wait)
+
+    def test_no_perms(self):
+        parser = CliParser()
+        args = parser.parse_arguments(["--no-perms"])
+        self.assertTrue(args.no_perms)
 
     def test_wait_interval(self):
         parser = CliParser()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -194,7 +194,7 @@ class CliParserTestCase(unittest.TestCase):
         )
         self.assertEqual(args.wait_interval, DEFAULT_FLOCK_WAIT_INTERVAL)
         self.assertFalse(args.no_wait)
-        self.assertFalse(args.no_perms)
+        self.assertFalse(args.no_permission_change)
         self.assertEqual(
             args.compression_level, DEFAULT_RSYNC_COMPRESSION_LEVEL
         )
@@ -427,10 +427,10 @@ class CliParserTestCase(unittest.TestCase):
         args = parser.parse_arguments(["--no-wait"])
         self.assertTrue(args.no_wait)
 
-    def test_no_perms(self):
+    def test_no_permission_change(self):
         parser = CliParser()
-        args = parser.parse_arguments(["--no-perms"])
-        self.assertTrue(args.no_perms)
+        args = parser.parse_arguments(["--no-permission-change"])
+        self.assertTrue(args.no_permission_change)
 
     def test_wait_interval(self):
         parser = CliParser()

--- a/tests/test_rsync.py
+++ b/tests/test_rsync.py
@@ -109,6 +109,34 @@ class RsyncTestCase(unittest.IsolatedAsyncioTestCase):
         )
 
     @patch("greenbone.feed.sync.rsync.exec_rsync", autospec=True)
+    async def test_rsync_with_no_perms(self, exec_mock: AsyncMock):
+        rsync = Rsync(perms=False)
+        await rsync.sync("rsync://foo.bar/baz", "/tmp/baz")
+
+        exec_mock.assert_awaited_once_with(
+            "--links",
+            "--times",
+            "--omit-dir-times",
+            "--recursive",
+            "--partial",
+            "--progress",
+            "-q",
+            "--compress-level=9",
+            "--delete",
+            "--no-perms",
+            "--copy-unsafe-links",
+            "--hard-links",
+            "rsync://foo.bar/baz",
+            "/tmp/baz",
+        )
+
+        args = exec_mock.await_args.args
+        self.assertNotIn("--perms", args)
+        self.assertFalse(
+            any(arg.startswith("--chmod") for arg in args),
+        )
+
+    @patch("greenbone.feed.sync.rsync.exec_rsync", autospec=True)
     async def test_rsync_with_exclude(self, exec_mock: AsyncMock):
         rsync = Rsync(exclude=["foo", Path("exclude/this")])
         await rsync.sync("rsync://foo.bar/baz", "/tmp/baz")

--- a/tests/test_rsync.py
+++ b/tests/test_rsync.py
@@ -109,8 +109,8 @@ class RsyncTestCase(unittest.IsolatedAsyncioTestCase):
         )
 
     @patch("greenbone.feed.sync.rsync.exec_rsync", autospec=True)
-    async def test_rsync_with_no_perms(self, exec_mock: AsyncMock):
-        rsync = Rsync(perms=False)
+    async def test_rsync_with_no_permission_change(self, exec_mock: AsyncMock):
+        rsync = Rsync(change_permissions=False)
         await rsync.sync("rsync://foo.bar/baz", "/tmp/baz")
 
         exec_mock.assert_awaited_once_with(


### PR DESCRIPTION
## Why

Some storage backends (bind mounts, network filesystems, container volumes) allow writing files but reject changing their modes. The sync currently always passes `--perms --chmod=Fugo+r,Fug+w,Dugo-s,Dugo+rx,Dug+w`, which makes rsync fail with a permission error on such targets.

## What

- Adds an opt-in `--no-permission-change` CLI flag, `no-permission-change` config variable, and `GREENBONE_FEED_SYNC_NO_PERMISSION_CHANGE` environment variable.
- When enabled, rsync runs with `--no-perms` instead of the default `--perms --chmod=...`.
- **Default behavior is unchanged** — permissions are still preserved by default.
- Wired through `Rsync(change_permissions=...)` from `main.py`; documented in `README.md`.

## Tests

- New tests for the rsync args, the parser flag, and the `main.py` wiring.
- Extended config tests (defaults, config-file, and environment override).
- Existing `main.py` tests updated to assert the default `change_permissions=True`.
- `ruff check` and `ruff format` clean.

---

Includes AI-generated code (GitHub Copilot).
