### PR TITLE
Add scan-config-json type

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ and types.
   - [report-formats-url](#report-formats-url)
   - [scan-configs-destination](#scan-configs-destination)
   - [scan-configs-url](#scan-configs-url)
+  - [scan-config-jsons-destination](#scan-config-jsons-destination)
+  - [scan-config-jsons-url](#scan-config-jsons-url)
   - [port-lists-destination](#port-lists-destination)
   - [port-lists-url](#port-lists-url)
   - [gvmd-lock-file](#gvmd-lock-file)
@@ -273,7 +275,7 @@ is only required for experts and testing purposes.
 | Config Variable      |                                                                                                                                                                                                                                    |
 | Environment Variable |                                                                                                                                                                                                                                    |
 | Default Value        | all                                                                                                                                                                                                                                |
-| Description          | Specifies which feed data should be downloaded. Possible values are `all`, `nvt`/`nvts`, `gvmd-data`, `scap`, `cert`, `notus`, `nasl`, `report-format`/`report-formats`, `scan-config`/`scan-configs` or `port-list`/`port-lists`. |
+| Description          | Specifies which feed data should be downloaded. Possible values are `all`, `nvt`/`nvts`, `gvmd-data`, `scap`, `cert`, `notus`, `nasl`, `report-format`/`report-formats`, `scan-config`/`scan-configs`, `scan-config-json`/`scan-config-jsons` or `port-list`/`port-lists`. |
 
 ### feed-url
 
@@ -444,6 +446,26 @@ is only required for experts and testing purposes.
 | Environment Variable | `GREENBONE_FEED_SYNC_SCAN_CONFIGS_URL`           |
 | Default Value        | `$FEED_URL/data-feed/$FEED_VERSION/scan-configs` |
 | Description          | URL to download the scan config data from.       |
+
+### scan-config-jsons-destination
+
+| Name                 | Value                                                                       |
+| -------------------- | --------------------------------------------------------------------------- |
+| CLI Argument         | `--scan-config-jsons-destination`                                           |
+| Config Variable      | scan-config-jsons-destination                                               |
+| Environment Variable | `GREENBONE_FEED_SYNC_SCAN_CONFIG_JSONS_DESTINATION`                         |
+| Default Value        | `$DESTINATION_PREFIX/gvm/data-objects/gvmd/$FEED_VERSION/scan-configs-json` |
+| Description          | Destination of the downloaded scan config JSON data.                        |
+
+### scan-config-jsons-url
+
+| Name                 | Value                                                 |
+| -------------------- | ----------------------------------------------------- |
+| CLI Argument         | `--scan-config-jsons-url`                             |
+| Config Variable      | scan-config-jsons-url                                 |
+| Environment Variable | `GREENBONE_FEED_SYNC_SCAN_CONFIG_JSONS_URL`           |
+| Default Value        | `$FEED_URL/data-feed/$FEED_VERSION/scan-configs-json` |
+| Description          | URL to download the scan config JSON data from.       |
 
 ### port-lists-destination
 

--- a/greenbone/feed/sync/config.py
+++ b/greenbone/feed/sync/config.py
@@ -298,6 +298,20 @@ _DEPENDENT_SETTINGS = (
         str,
     ),
     DependentSetting(
+        "scan-config-jsons-destination",
+        "GREENBONE_FEED_SYNC_SCAN_CONFIG_JSONS_DESTINATION",
+        lambda values: f"{values['gvmd-data-destination']}/scan-configs-json",
+        Path,
+    ),
+    DependentSetting(
+        "scan-config-jsons-url",
+        "GREENBONE_FEED_SYNC_SCAN_CONFIG_JSONS_URL",
+        lambda values: (
+            f"{values['feed-url']}/data-feed/{values['feed-release']}/scan-configs-json/"
+        ),
+        str,
+    ),
+    DependentSetting(
         "port-lists-destination",
         "GREENBONE_FEED_SYNC_PORT_LISTS_DESTINATION",
         lambda values: f"{values['gvmd-data-destination']}/port-lists",

--- a/greenbone/feed/sync/main.py
+++ b/greenbone/feed/sync/main.py
@@ -158,6 +158,12 @@ async def feed_sync(console: Console, error_console: Console) -> int:
             destination=args.scan_configs_destination,
         ),
         Sync(
+            name="scan config JSONs",
+            types=("scan-config-json",),
+            url=args.scan_config_jsons_url,
+            destination=args.scan_config_jsons_destination,
+        ),
+        Sync(
             name="port lists",
             types=("port-list"),
             url=args.port_lists_url,

--- a/greenbone/feed/sync/parser.py
+++ b/greenbone/feed/sync/parser.py
@@ -39,7 +39,13 @@ def feed_type(value: str) -> str:
 
     value = value.replace("_", "-").lower()
 
-    if value in ("nvts", "report-formats", "port-lists", "scan-configs"):
+    if value in (
+        "nvts",
+        "report-formats",
+        "port-lists",
+        "scan-configs",
+        "scan-config-jsons",
+    ):
         return value[:-1]
 
     return value
@@ -113,6 +119,7 @@ class CliParser:
                 "nasl",
                 "report-format",
                 "scan-config",
+                "scan-config-json",
                 "port-list",
             ],
             default="all",
@@ -210,6 +217,17 @@ class CliParser:
         data_objects_url_group.add_argument(
             "--scan-configs-url",
             help="URL to download the scan config data from. "
+            "(Default: %(default)s)",
+        )
+        data_objects_destination_group.add_argument(
+            "--scan-config-jsons-destination",
+            type=Path,
+            help="Destination of the downloaded scan config JSON data. "
+            "(Default: %(default)s)",
+        )
+        data_objects_url_group.add_argument(
+            "--scan-config-jsons-url",
+            help="URL to download the scan config JSON data from. "
             "(Default: %(default)s)",
         )
         data_objects_destination_group.add_argument(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,7 +34,7 @@ class ConfigTestCase(unittest.TestCase):
     def test_defaults(self):
         values = Config.load()
 
-        self.assertEqual(len(values), 32)
+        self.assertEqual(len(values), 34)
         self.assertEqual(
             values["destination-prefix"], Path(DEFAULT_DESTINATION_PREFIX)
         )
@@ -104,6 +104,18 @@ class ConfigTestCase(unittest.TestCase):
             f"{DEFAULT_RSYNC_URL}/data-feed/{DEFAULT_FEED_RELEASE}/scan-configs/",
         )
         self.assertEqual(
+            values["scan-config-jsons-destination"],
+            Path(DEFAULT_DESTINATION_PREFIX)
+            / "gvm"
+            / "data-objects"
+            / "gvmd"
+            / "scan-configs-json",
+        )
+        self.assertEqual(
+            values["scan-config-jsons-url"],
+            f"{DEFAULT_RSYNC_URL}/data-feed/{DEFAULT_FEED_RELEASE}/scan-configs-json/",
+        )
+        self.assertEqual(
             values["port-lists-destination"],
             Path(DEFAULT_DESTINATION_PREFIX)
             / "gvm"
@@ -159,6 +171,8 @@ report-formats-destination = "/usr/lib/report-formats"
 report-formats-url = "rsync://foo.bar/report-formats"
 scan-configs-destination = "/usr/lib/scan-configs"
 scan-configs-url = "rsync://foo.bar/scan-configs"
+scan-config-jsons-destination = "/usr/lib/scan-configs-json"
+scan-config-jsons-url = "rsync://foo.bar/scan-configs-json"
 port-lists-destination = "/usr/lib/port-lists"
 port-lists-url = "rsync://foo.bar/port-lists"
 openvas-lock-file = "/usr/lib/openvas.lock"
@@ -217,6 +231,14 @@ feed-release = "1.2.3"
         )
         self.assertEqual(
             values["scan-configs-url"], "rsync://foo.bar/scan-configs"
+        )
+        self.assertEqual(
+            values["scan-config-jsons-destination"],
+            Path("/usr/lib/scan-configs-json"),
+        )
+        self.assertEqual(
+            values["scan-config-jsons-url"],
+            "rsync://foo.bar/scan-configs-json",
         )
         self.assertEqual(
             values["port-lists-destination"],
@@ -350,6 +372,8 @@ feed-url = "rsync://foo.bar"
             "GREENBONE_FEED_SYNC_REPORT_FORMATS_URL": "rsync://foo.bar/report-formats",
             "GREENBONE_FEED_SYNC_SCAN_CONFIGS_DESTINATION": "/usr/lib/scan-configs",
             "GREENBONE_FEED_SYNC_SCAN_CONFIGS_URL": "rsync://foo.bar/scan-configs",
+            "GREENBONE_FEED_SYNC_SCAN_CONFIG_JSONS_DESTINATION": "/usr/lib/scan-configs-json",
+            "GREENBONE_FEED_SYNC_SCAN_CONFIG_JSONS_URL": "rsync://foo.bar/scan-configs-json",
             "GREENBONE_FEED_SYNC_PORT_LISTS_DESTINATION": "/usr/lib/port-lists",
             "GREENBONE_FEED_SYNC_PORT_LISTS_URL": "rsync://foo.bar/port-lists",
             "GREENBONE_FEED_SYNC_OPENVAS_LOCK_FILE": "/usr/lib/openvas.lock",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -69,6 +69,17 @@ class FeedTypeTestCase(unittest.TestCase):
         self.assertEqual("scan-config", feed_type("SCAN-CONFIG"))
         self.assertEqual("scan-config", feed_type("SCAN-CONFIGS"))
 
+
+def test_scan_config_json(self):
+    self.assertEqual("scan-config-json", feed_type("scan-config-json"))
+    self.assertEqual("scan-config-json", feed_type("scan-config-jsons"))
+    self.assertEqual("scan-config-json", feed_type("scan_config_json"))
+    self.assertEqual("scan-config-json", feed_type("scan_config_jsons"))
+    self.assertEqual("scan-config-json", feed_type("SCAN_CONFIG_JSON"))
+    self.assertEqual("scan-config-json", feed_type("SCAN_CONFIG_JSONS"))
+    self.assertEqual("scan-config-json", feed_type("SCAN-CONFIG-JSON"))
+    self.assertEqual("scan-config-json", feed_type("SCAN-CONFIG-JSONS"))
+
     def test_gvmd_data(self):
         self.assertEqual("gvmd-data", feed_type("gvmd-data"))
         self.assertEqual("gvmd-data", feed_type("gvmd_data"))
@@ -171,6 +182,18 @@ class CliParserTestCase(unittest.TestCase):
         self.assertEqual(
             args.scan_configs_url,
             f"{DEFAULT_RSYNC_URL}/data-feed/{DEFAULT_FEED_RELEASE}/scan-configs/",
+        )
+        self.assertEqual(
+            args.scan_config_jsons_destination,
+            Path(DEFAULT_DESTINATION_PREFIX)
+            / "gvm"
+            / "data-objects"
+            / "gvmd"
+            / "scan-configs-json",
+        )
+        self.assertEqual(
+            args.scan_config_jsons_url,
+            f"{DEFAULT_RSYNC_URL}/data-feed/{DEFAULT_FEED_RELEASE}/scan-configs-json/",
         )
         self.assertEqual(
             args.port_lists_destination,
@@ -390,7 +413,24 @@ class CliParserTestCase(unittest.TestCase):
         )
         self.assertEqual(args.scan_configs_url, "rsync://foo.bar/scan-configs")
 
-    def test_port_lists_destination(self):
+    def test_scan_config_jsons_destination(self):
+        parser = CliParser()
+        args = parser.parse_arguments(
+            ["--scan-config-jsons-destination", "foo/bar"]
+        )
+        self.assertEqual(args.scan_config_jsons_destination, Path("foo/bar"))
+
+    def test_scan_config_jsons_url(self):
+        parser = CliParser()
+        args = parser.parse_arguments(
+            ["--scan-config-jsons-url", "rsync://foo.bar/scan-configs-json"]
+        )
+        self.assertEqual(
+            args.scan_config_jsons_url,
+            "rsync://foo.bar/scan-configs-json",
+        )
+
+    def test_port_lists_destinatßion(self):
         parser = CliParser()
         args = parser.parse_arguments(["--port-lists-destination", "foo/bar"])
         self.assertEqual(args.port_lists_destination, Path("foo/bar"))
@@ -678,6 +718,19 @@ wait-interval = 100
         args = parser.parse_arguments(["--type", "SCAN_CONFIGS"])
         self.assertEqual(args.type, "scan-config")
 
+        args = parser.parse_arguments(["--type", "scan-config-json"])
+        self.assertEqual(args.type, "scan-config-json")
+        args = parser.parse_arguments(["--type", "SCAN-CONFIG-JSON"])
+        self.assertEqual(args.type, "scan-config-json")
+        args = parser.parse_arguments(["--type", "scan_config_json"])
+        self.assertEqual(args.type, "scan-config-json")
+        args = parser.parse_arguments(["--type", "SCAN_CONFIG_JSON"])
+        self.assertEqual(args.type, "scan-config-json")
+        args = parser.parse_arguments(["--type", "scan-config-jsons"])
+        self.assertEqual(args.type, "scan-config-json")
+        args = parser.parse_arguments(["--type", "SCAN_CONFIG_JSONS"])
+        self.assertEqual(args.type, "scan-config-json")
+
         args = parser.parse_arguments(["--type", "port-list"])
         self.assertEqual(args.type, "port-list")
         args = parser.parse_arguments(["--type", "PORT-LIST"])
@@ -752,6 +805,10 @@ sed diam nonumy eirmod tempor
                 f"ssh://a_user@some.feed.server/enterprise/data-feed/{DEFAULT_FEED_RELEASE}/scan-configs/",
             )
             self.assertEqual(
+                args.scan_config_jsons_url,
+                f"ssh://a_user@some.feed.server/enterprise/data-feed/{DEFAULT_FEED_RELEASE}/scan-configs-json/",
+            )
+            self.assertEqual(
                 args.notus_url,
                 f"ssh://a_user@some.feed.server/enterprise/vulnerability-feed/{DEFAULT_FEED_RELEASE}/vt-data/notus/",
             )
@@ -792,6 +849,10 @@ sed diam nonumy eirmod tempor
         self.assertEqual(
             args.scan_configs_url,
             f"rsync://feed.community.greenbone.net/community/data-feed/{DEFAULT_FEED_RELEASE}/scan-configs/",
+        )
+        self.assertEqual(
+            args.scan_config_jsons_url,
+            f"rsync://feed.community.greenbone.net/community/data-feed/{DEFAULT_FEED_RELEASE}/scan-configs-json/",
         )
         self.assertEqual(
             args.notus_url,


### PR DESCRIPTION
## What

Add a dedicated `scan-config-json` / `scan-config-jsons` feed sync type and related URL/destination settings.

## Why

OPENVAS DETECT/OEM customers need scan configs as JSON, but these files should be synced only when explicitly requested.

## References

[DEVOPS-2126](https://jira.greenbone.net/browse/DEVOPS-2126)

## Checklist


- [ ] Tests
validated with parser/config unit tests, running Ruff and black.
