### PR TITLE
Change: default value for FEED_RELEASE from 24.10 to 25.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ is only required for experts and testing purposes.
 | CLI Argument         | `--feed-release`                                                                                    |
 | Config Variable      | feed-release                                                                                        |
 | Environment Variable | `GREENBONE_FEED_SYNC_FEED_RELEASE`                                                                  |
-| Default Value        | `24.10`                                                                                             |
+| Default Value        | `25.0`                                                                                             |
 | Description          | Release series of the feed to be downloaded. Download destinations and URLs will use this variable. |
 
 ### destination-prefix

--- a/greenbone/feed/sync/config.py
+++ b/greenbone/feed/sync/config.py
@@ -40,7 +40,7 @@ def maybe_int(value: str | None) -> int | str | None:
     return value
 
 
-DEFAULT_FEED_RELEASE = "24.10"
+DEFAULT_FEED_RELEASE = "25.0"
 
 DEFAULT_DESTINATION_PREFIX = "/var/lib/"
 

--- a/greenbone/feed/sync/config.py
+++ b/greenbone/feed/sync/config.py
@@ -79,7 +79,7 @@ def resolve_gvmd_data_destination(values: ValuesDict) -> str:
 
     return (
         f"{values['destination-prefix']}/{path}"
-        if major >= 24 and minor >= 10
+        if major >= 24
         else f"{values['destination-prefix']}/{path}/{feed_release}"
     )
 

--- a/greenbone/feed/sync/parser.py
+++ b/greenbone/feed/sync/parser.py
@@ -125,7 +125,7 @@ class CliParser:
         )
         parser.add_argument(
             "--feed-release",
-            help="Release series of the feed to download for example 22.04 or 24.10. (Default: %(default)s)",
+            help="Release series of the feed to download for example 24.10 or 25.0. (Default: %(default)s)",
         )
         parser.add_argument(
             "--destination-prefix",


### PR DESCRIPTION
## What
Change: default value for FEED_RELEASE from 24.10 to 25.0
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
24.10 is old feed version, we should use 25.0 instead
<!-- Describe why are these changes necessary? -->

## References
DEVOPS-2194
<!-- Add identifier for issue tickets, links to other PRs, etc. -->


