### PR TITLE
Change: Set default to 25.0 feed

### DIFF
--- a/greenbone/feed/sync/config.py
+++ b/greenbone/feed/sync/config.py
@@ -40,7 +40,7 @@ def maybe_int(value: str | None) -> int | str | None:
     return value
 
 
-DEFAULT_FEED_RELEASE = "24.10"
+DEFAULT_FEED_RELEASE = "25.0"
 
 DEFAULT_DESTINATION_PREFIX = "/var/lib/"
 
@@ -79,7 +79,7 @@ def resolve_gvmd_data_destination(values: ValuesDict) -> str:
 
     return (
         f"{values['destination-prefix']}/{path}"
-        if major >= 24 and minor >= 10
+        if major >= 24 and minor >= 0
         else f"{values['destination-prefix']}/{path}/{feed_release}"
     )
 

--- a/greenbone/feed/sync/config.py
+++ b/greenbone/feed/sync/config.py
@@ -79,7 +79,7 @@ def resolve_gvmd_data_destination(values: ValuesDict) -> str:
 
     return (
         f"{values['destination-prefix']}/{path}"
-        if major >= 24 and minor >= 10 or major >= 25
+        if (major >= 24 and minor >= 10) or major >= 25
         else f"{values['destination-prefix']}/{path}/{feed_release}"
     )
 

--- a/greenbone/feed/sync/config.py
+++ b/greenbone/feed/sync/config.py
@@ -79,7 +79,7 @@ def resolve_gvmd_data_destination(values: ValuesDict) -> str:
 
     return (
         f"{values['destination-prefix']}/{path}"
-        if major >= 24 and minor >= 0
+        if major >= 24 and minor >= 10 or major >= 25
         else f"{values['destination-prefix']}/{path}/{feed_release}"
     )
 


### PR DESCRIPTION
## What
Change: Set default to 25.0 feed
Fix: gvmd data path for >= 24.10

## Why
Current 25.0:
⠋ Downloading Notus files from 
ssh://gsf20241002001@feed.greenbone.net/enterprise/vulnerability-feed/25.0/vt-da
ta/notus/ to /var/lib/notus⠋ Downloading NASL files from 
ssh://gsf20241002001@feed.greenbone.net/enterprise/vulnerability-feed/25.0/vt-da
ta/nasl/ to /var/lib/openvas/plugins
Releasing lock on /var/lib/openvas/feed-update.lock

Trying to acquire lock on /var/lib/gvm/feed-update.lock
Acquired lock on /var/lib/gvm/feed-update.lock
⠋ Downloading SCAP data from 
ssh://gsf20241002001@feed.greenbone.net/enterprise/vulnerability-feed/25.0/scap-
data/ to /var/lib/gvm/scap-data⠋ Downloading CERT-Bund data from 
ssh://gsf20241002001@feed.greenbone.net/enterprise/vulnerability-feed/25.0/cert-
data/ to /var/lib/gvm/cert-data⠋ Downloading gvmd data from 
ssh://gsf20241002001@feed.greenbone.net/enterprise/data-feed/25.0/ to 
/var/lib/gvm/data-objects/gvmd/25.0
Releasing lock on /var/lib/gvm/feed-update.lock

Current 24.10:
⠋ Downloading Notus files from 
ssh://gsf20241002001@feed.greenbone.net/enterprise/vulnerability-feed/24.10/vt-d
ata/notus/ to /var/lib/notus⠋ Downloading NASL files from 
ssh://gsf20241002001@feed.greenbone.net/enterprise/vulnerability-feed/24.10/vt-d
ata/nasl/ to /var/lib/openvas/plugins
Releasing lock on /var/lib/openvas/feed-update.lock

Trying to acquire lock on /var/lib/gvm/feed-update.lock
Acquired lock on /var/lib/gvm/feed-update.lock
⠋ Downloading SCAP data from 
ssh://gsf20241002001@feed.greenbone.net/enterprise/vulnerability-feed/24.10/scap
-data/ to /var/lib/gvm/scap-data⠋ Downloading CERT-Bund data from 
ssh://gsf20241002001@feed.greenbone.net/enterprise/vulnerability-feed/24.10/cert
-data/ to /var/lib/gvm/cert-data⠋ Downloading gvmd data from 
ssh://gsf20241002001@feed.greenbone.net/enterprise/data-feed/24.10/ to 
/var/lib/gvm/data-objects/gvmd
Releasing lock on /var/lib/gvm/feed-update.lock



