### PR TITLE
Fix masking permission errors during file locking

### DIFF
--- a/greenbone/feed/sync/helper.py
+++ b/greenbone/feed/sync/helper.py
@@ -59,55 +59,61 @@ async def flock_wait(
         ) from e
 
     try:
-        with path.open("w", encoding="utf8") as fd0:
-            has_lock = False
-            while not has_lock:
-                try:
-                    if console:
-                        console.print(
-                            f"Trying to acquire lock on {path.absolute()}"
-                        )
-
-                    fcntl.flock(fd0, fcntl.LOCK_EX | fcntl.LOCK_NB)
-
-                    if console:
-                        console.print(f"Acquired lock on {path.absolute()}")
-
-                    has_lock = True
-                    path.chmod(mode=0o660)
-                except OSError as e:
-                    if e.errno in (errno.EAGAIN, errno.EACCES):
-                        if wait_interval is None:
-                            raise FileLockingError(
-                                f"{path.absolute()} is locked. Another process "
-                                "related to the feed update may already running."
-                            ) from None
-
-                        if console:
-                            console.print(
-                                f"{path.absolute()} is locked by another process. "
-                                f"Waiting {wait_interval} seconds before next try."
-                            )
-                        await asyncio.sleep(wait_interval)
-                    else:
-                        raise
-
-            try:
-                yield
-            finally:
-                try:
-                    # free the lock
-                    if console:
-                        console.print(f"Releasing lock on {path.absolute()}")
-
-                    fcntl.flock(fd0, fcntl.LOCK_UN)
-                except OSError:
-                    pass
+        fd0 = path.open("w", encoding="utf8")
     except PermissionError as e:
         raise FileLockingError(
-            "Permission error while trying to open the lock file "
-            f"{path.absolute()}"
+            f"Permission error while trying to open the lock file {path.absolute()}"
         ) from e
+
+    try:
+        has_lock = False
+        while not has_lock:
+            try:
+                if console:
+                    console.print(
+                        f"Trying to acquire lock on {path.absolute()}"
+                    )
+
+                fcntl.flock(fd0, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+                if console:
+                    console.print(f"Acquired lock on {path.absolute()}")
+
+                has_lock = True
+                path.chmod(mode=0o660)
+            except OSError as e:
+                if e.errno in (errno.EAGAIN, errno.EACCES):
+                    if wait_interval is None:
+                        raise FileLockingError(
+                            f"{path.absolute()} is locked. Another process "
+                            "related to the feed update may already running."
+                        ) from None
+
+                    if console:
+                        console.print(
+                            f"{path.absolute()} is locked by another process. "
+                            f"Waiting {wait_interval} seconds before next try."
+                        )
+                    await asyncio.sleep(wait_interval)
+                else:
+                    raise
+
+        try:
+            yield
+        finally:
+            try:
+                # free the lock
+                if console:
+                    console.print(f"Releasing lock on {path.absolute()}")
+
+                fcntl.flock(fd0, fcntl.LOCK_UN)
+            except OSError:
+                pass
+    finally:
+        try:
+            fd0.close()
+        except OSError:
+            pass
 
 
 class Spinner:

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -154,6 +154,22 @@ class FlockTestCase(unittest.IsolatedAsyncioTestCase):
                 ):
                     pass
 
+    async def test_normal_permission_error(self):
+        with temp_directory() as temp_dir:
+            lock_file = temp_dir / "file.lock"
+            lock_file.touch()
+            some_other_file = temp_dir / "some_other_file"
+            with self.assertRaisesRegex(
+                PermissionError,
+                f"^\[Errno 13\] Permission denied: '{some_other_file.absolute()}'$",  # type: ignore
+            ):
+                async with flock_wait(
+                    lock_file,
+                ):
+                    some_other_file.touch()
+                    some_other_file.chmod(0)
+                    some_other_file.open("w", encoding="utf8")
+
 
 class SpinnerTestCase(unittest.TestCase):
     @patch("greenbone.feed.sync.helper.Live", autospec=True)


### PR DESCRIPTION


## What
Fix masking permission errors during file locking

## Why

Don't hide permission errors on other files while holding a lock on a lock file. Before the "normal" permission errors where interpreted as permission errors on the lock file itself and therefore converted to a FileLockingError. With this change only the PermissionError on the lock file itself is a FileLockingError and other PermissionErrors are raised to the user of flock_wait instead.


## References

Closes #364

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


